### PR TITLE
Replaced mean_squared_error with root_mean_squared_error in rmse func…

### DIFF
--- a/improve/metrics.py
+++ b/improve/metrics.py
@@ -3,7 +3,7 @@
 import sys
 
 from scipy.stats.mstats import pearsonr, spearmanr
-from sklearn.metrics import r2_score, mean_squared_error
+from sklearn.metrics import r2_score, mean_squared_error, root_mean_squared_error
 
 
 def str2Class(str):
@@ -75,7 +75,7 @@ def rmse(y_true, y_pred):
     -------
         float value corresponding to RMSE. If several outputs, errors of all outputs are averaged with uniform weight.
     """
-    rmse = mean_squared_error(y_true, y_pred, squared=False)
+    rmse = root_mean_squared_error(y_true, y_pred)
     return rmse
 
 


### PR DESCRIPTION
The squared keyword is depricated and not supported in sklearn versions > 1.6
Using root_mean_squared_error instead.

Fixes #11 