### PR TITLE
Wilke/cli optional arguments

### DIFF
--- a/improve/CSA/Config/Common.py
+++ b/improve/CSA/Config/Common.py
@@ -90,7 +90,6 @@ class Config():
                               cli=None, # Command Line Interface of type CLI
                               section='DEFAULT',
                               config_file=None,
-                              default_model=None,
                               additional_definitions=None,
                               required=None,):
         """Merge parameters from command line and config file."""
@@ -99,6 +98,7 @@ class Config():
 
 
         if cli and cli.args.log_level:
+            self.logger.debug("Setting log level to %s", cli.args.log_level)
             self.args = cli.args
             self.logger.setLevel(cli.args.log_level)
             self.log_level = cli.args.log_level
@@ -112,6 +112,7 @@ class Config():
 
         # Check if config_file is set and file exists
         if config_file:
+            self.logger.debug("Config file: %s", config_file)
             if os.path.isfile(config_file):
                 self.config_file = config_file
             else:

--- a/improve/CSA/Config/Common.py
+++ b/improve/CSA/Config/Common.py
@@ -7,8 +7,16 @@ FORMAT = '%(levelname)s %(name)s %(asctime)s:\t%(message)s'
 class Config():
     def __init__(self):
         self.option = None
-    
-
+        self.config = None
+        self.config_file = None
+        self.input_dir = None
+        self.output_dir = None
+        self.log_level = None
+        self.logger = None
+        self.option = None
+        self.params = None
+        self.args = None
+        # Default format for logging
         logging.basicConfig(format=FORMAT)
         self.logger=logging.getLogger('Common.Config')
         
@@ -35,9 +43,6 @@ class Config():
                 print(k, self.option[key][k])
 
         # if ini file load ini file else load json file
-        
-
-
         pass
 
     def save_config(self, file):
@@ -55,6 +60,109 @@ class Config():
         
 
         pass
+
+    def set_param(self, section, key, value):
+        self.option[section][key] = value
+        setattr(self, key, value)
+        pass
+
+
+    def get_param(self, section="DEFAULT" , key=None) -> str:
+      
+        error=None
+
+        if self.config.has_option(section, key):
+            value=self.config[section][key]
+        else:
+            error="Can't find option " + str(key)
+            self.logger.error(error)
+            value=None
+
+        return value  
+
+
+    def get_enviorment_variable(self):
+
+        pass
+
+
+    def initialize_parameters(self,
+                              cli=None, # Command Line Interface of type CLI
+                              section='DEFAULT',
+                              config_file=None,
+                              default_model=None,
+                              additional_definitions=None,
+                              required=None,):
+        """Merge parameters from command line and config file."""
+
+        # Set log level
+
+
+        if cli and cli.args.log_level:
+            self.args = cli.args
+            self.logger.setLevel(cli.args.log_level)
+            self.log_level = cli.args.log_level
+
+        # preserve the type of the object
+        current_class = self.__class__
+        self.__class__ = Config
+
+
+        self.logger.debug("Initializing parameters for %s", section)
+
+        # Check if config_file is set and file exists
+        if config_file:
+            if os.path.isfile(config_file):
+                self.config_file = config_file
+            else:
+                self.logger.critical("Can't find config file: %s", config_file)
+                self.config_file = None
+
+            # Load Config        
+            self.load_config(self.config_file)
+    
+            # Set/update config with arguments from command line
+            self.logger.debug("Updating config")
+
+            # create dictionary of parameters from list of tuples. The list of tuples is the result of cli.args.user_specified 
+            # which is a list of tuples of the form (name, value) where name is the name of the parameter and value is the value of the parameter
+            user_provided_params = dict(cli.user_specified)
+            self.logger.debug("User provided parameters: %s", user_provided_params)
+
+            for k in cli.params :
+                # Test if k is a valid parameter and has a value
+                if self.get_param(section, k) is None:
+                    self.logger.error("Invalid parameter: %s", k)
+                
+                self.set_param(section, k, cli.params[k])
+
+
+                self.logger.debug("Setting %s to %s", k, cli.params[k])
+                self.set_param(section, k, cli.params[k])
+                # self.config[section][k] = cli.params[k]
+        
+        # Update input and output directories    
+        self.output_dir = self.config[section]['output_dir']
+        self.input_dir = self.config[section]['input_dir']
+        self.log_level = self.config[section]['log_level']
+        self.logger.setLevel(self.log_level)
+        
+        # Set environment variables 
+    
+        os.environ["IMPROVE_DATA_DIR"] = self.input_dir
+        os.environ["IMPROVE_OUTPUT_DIR"] = self.output_dir
+        os.environ["IMPROVE_LOG_LEVEL"] = self.config[section]['log_level']
+
+     
+
+
+        # Create output directory if not exists
+        if not os.path.isdir(self.output_dir):
+            self.logger.debug("Creating output directory: %s", self.output_dir)
+            os.makedirs(self.output_dir)
+    
+        self.__class__ = current_class
+        return self.dict()
 
 if __name__ == "__main__":
     cfg = Config()

--- a/improve/CSA/Config/Parsl.py
+++ b/improve/CSA/Config/Parsl.py
@@ -1,5 +1,5 @@
 from parsl.config import Config
-from .Common import Config as BaseConfig
+from improve.CSA.Config.Base import Config as BaseConfig
 
 
 class Config(BaseConfig):
@@ -13,12 +13,22 @@ class Config(BaseConfig):
 
 
 
-
+    def initialize_parameters(self, cli=None, config_file=None, additional_definitions=None, required=None):
+        self.logger.debug(f"Initializing parameters for %s", "PARSL")
+        
+        return super().initialize_parameters(cli, "PARSL", config_file, additional_definitions, required)
+    
 
 
 
 
 if __name__ == "__main__":
+    from improve.CSA.CLI import CLI
+    cli=CLI()
+    cli.set_command_line_options()
+    cli.get_command_line_options()
     cfg=Config()
-    cfg.load_config('parsl.config.ini')
+    cfg.logger.setLevel("DEBUG")
+    cfg.initialize_parameters(cli=cli)
+    # cfg.load_config('parsl.config.ini')
     print(cfg.option)


### PR DESCRIPTION
Allow for defaults on the command line, but distinguish if values are defaults or set by the user. It uses the action parameter, which might clash with future uses.