### PR TITLE
fix return self.cli_params instead of self.params

### DIFF
--- a/improvelib/initializer/cli.py
+++ b/improvelib/initializer/cli.py
@@ -119,8 +119,7 @@ class CLI:
             if self.cli_explicit[explicit_key]:
                 self.cli_params[explicit_key] = self.parser_params[explicit_key]
 
-
-        return self.params
+        return self.cli_params
 
     def _check_option(self, option) -> bool:
         pass


### PR DESCRIPTION
Fixed return of `self.cli_params` instead of `self.params`

Fixes #36 