### PR TITLE
Sara/unittest

### DIFF
--- a/test/test_default_1.cfg
+++ b/test/test_default_1.cfg
@@ -3,9 +3,8 @@ splits_dir=test_splits
 preprocess_test_var=preprocess
 
 [Train]
-model_name=LGBM
-model_framework=pytorch
-model_version=1.0
+train_test_var=10
+model_file_name=test_model
 
 [Infer]
 batch_size=10

--- a/test/test_default_1.cfg
+++ b/test/test_default_1.cfg
@@ -1,0 +1,11 @@
+[Preprocess]
+splits_dir=test_splits
+preprocess_test_var=preprocess
+
+[Train]
+model_name=LGBM
+model_framework=pytorch
+model_version=1.0
+
+[Infer]
+batch_size=10

--- a/test/test_default_1.cfg
+++ b/test/test_default_1.cfg
@@ -7,4 +7,4 @@ train_test_var=10
 model_file_name=test_model
 
 [Infer]
-batch_size=10
+json_scores_suffix=test_scores

--- a/test/test_default_2.cfg
+++ b/test/test_default_2.cfg
@@ -1,0 +1,10 @@
+[Preprocess]
+splits_dir=test_splits_b
+
+[Train]
+model_name=LGBM
+model_framework=pytorch
+model_version=1.0
+
+[Infer]
+batch_size=10

--- a/test/test_default_2.cfg
+++ b/test/test_default_2.cfg
@@ -5,4 +5,4 @@ splits_dir=test_splits_b
 epochs=20
 
 [Infer]
-batch_size=10
+infer_test_var=test_infer

--- a/test/test_default_2.cfg
+++ b/test/test_default_2.cfg
@@ -2,9 +2,7 @@
 splits_dir=test_splits_b
 
 [Train]
-model_name=LGBM
-model_framework=pytorch
-model_version=1.0
+epochs=20
 
 [Infer]
 batch_size=10

--- a/test/test_infer_params.py
+++ b/test/test_infer_params.py
@@ -1,0 +1,85 @@
+import sys
+from pathlib import Path
+from typing import Dict
+
+from improvelib.applications.drug_response_prediction.config import DRPInferConfig
+
+# Global variables
+filepath = Path(__file__).resolve().parent  # [Req]
+
+# Define parameters for the script
+test_model_infer_params = [
+        # see argparse.ArgumentParser.add_argument() for more information
+        {
+            # name of the argument
+            "name": "y_data_files",
+            # type of the argument
+            "type": str,
+            # number of arguments that should be consumed
+            "nargs": "+",
+            # help message
+            "help": "List of files that contain the y (prediction variable) data.",
+        },
+        {
+            # name of the argument
+            "name": "supplement",
+            # type of the argument
+            "type": str,
+            # number of arguments that should be consumed
+            "nargs": 2,
+            # name of the argument in usage messages
+            "metavar": ("FILE", "TYPE"),
+            # action to be taken when this argument is encountered
+            "action": "append",
+            # default value of the argument
+            "default": [ ('a' , 'b')],
+            "help": "Supplemental data tuple FILE and TYPE. FILE is in INPUT_DIR.",   # help message
+        }
+    ]
+
+
+# Default functions for all improve scripts are main and run
+# main initializes parameters and calls run with the parameters
+# run is the main function that executes the script or can be imported and used in other scripts
+
+def run(params: Dict, logger=None):
+    """ Run model inference.
+
+    Args:
+        params (dict): dict of CANDLE/IMPROVE parameters and parsed values.
+        cfg (Infer): Infer Config object. Default is None. 
+
+    Returns:
+        str: status of inference ("Success.").
+    """
+
+    logger.info("Running model inference.") if logger else print(
+        "Running model inference.")
+
+     ###### Place your code here ########
+
+    logger.debug(f"Loading model and data from {params['input_dir']}.")
+    ###### Place your code here ######
+
+    logger.debug(f"Inference results.")
+    ###### Place your code here ######
+    
+    logger.info(f"Run completed. Results saved in {params['output_dir']}.")
+    return "Success."
+
+
+def main(args):
+    """ Main function for inference."""
+    
+    cfg = DRPInferConfig()
+    params = cfg.initialize_parameters(filepath,
+                                    default_config="test_default_1.cfg",
+                                    # additional_cli_section='My section',
+                                    additional_definitions=test_model_infer_params,
+                                    required=None
+                                    )
+    print("Infer parameters:", params)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/test/test_infer_params.py
+++ b/test/test_infer_params.py
@@ -12,28 +12,12 @@ test_model_infer_params = [
         # see argparse.ArgumentParser.add_argument() for more information
         {
             # name of the argument
-            "name": "y_data_files",
+            "name": "infer_test_var",
             # type of the argument
             "type": str,
-            # number of arguments that should be consumed
-            "nargs": "+",
             # help message
-            "help": "List of files that contain the y (prediction variable) data.",
-        },
-        {
-            # name of the argument
-            "name": "supplement",
-            # type of the argument
-            "type": str,
-            # number of arguments that should be consumed
-            "nargs": 2,
-            # name of the argument in usage messages
-            "metavar": ("FILE", "TYPE"),
-            # action to be taken when this argument is encountered
-            "action": "append",
-            # default value of the argument
-            "default": [ ('a' , 'b')],
-            "help": "Supplemental data tuple FILE and TYPE. FILE is in INPUT_DIR.",   # help message
+            "help": "Test variable for infer.",
+            "default": "infer", # must include default, otherwise not defined
         }
     ]
 
@@ -56,7 +40,7 @@ def run(params: Dict, logger=None):
     logger.info("Running model inference.") if logger else print(
         "Running model inference.")
 
-     ###### Place your code here ########
+    ###### Place your code here ########
 
     logger.debug(f"Loading model and data from {params['input_dir']}.")
     ###### Place your code here ######
@@ -78,7 +62,7 @@ def main(args):
                                     additional_definitions=test_model_infer_params,
                                     required=None
                                     )
-    print("Infer parameters:", params)
+    return params
 
 
 if __name__ == "__main__":

--- a/test/test_preprocess_params.py
+++ b/test/test_preprocess_params.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+from typing import Dict
+
+from improvelib.applications.drug_response_prediction.config import DRPPreprocessConfig
+
+# Global variables
+filepath = Path(__file__).resolve().parent  # [Req]
+
+# Define parameters for the script
+test_model_preprocess_params = [
+        # see argparse.ArgumentParser.add_argument() for more information
+        {
+            # name of the argument
+            "name": "preprocess_test_var",
+            # type of the argument
+            "type": str,
+            # help message
+            "help": "Test variable for preprocess.",
+            "default": "prep", # must include default, otherwise not defined
+        }
+    ]
+
+
+# Default functions for all improve scripts are main and run
+# main initializes parameters and calls run with the parameters
+# run is the main function that executes the script or can be imported and used in other scripts
+
+def run(params: Dict, logger=None):
+    """ Run data preprocessing.
+
+    Args:
+        params (dict): dict of CANDLE/IMPROVE parameters and parsed values.
+        cfg (Preprocess): Preprocess Config object. Default is None. 
+
+    Returns:
+        str: status of preprocessing ("Success.").
+    """
+
+    logger.info("Running preprocessing.") if logger else print(
+        "Running preprocessing.")
+
+     ###### Place your code here ########
+
+    logger.debug(f"Loading data from {params['input_dir']}.")
+    ###### Place your code here ######
+
+    logger.debug(f"Creating data from {params['input_dir']}.")
+    ###### Place your code here ######
+    
+    logger.info(f"Run completed. Data saved in {params['output_dir']}.")
+    return "Success."
+
+
+def main(args):
+    """ Main function for preprocessing."""
+    
+    cfg = DRPPreprocessConfig()
+    params = cfg.initialize_parameters(filepath,
+                                    default_config="test_default_1.cfg",
+                                    # additional_cli_section='My section',
+                                    additional_definitions=test_model_preprocess_params,
+                                    required=None
+                                    )
+    print(params)
+    print(test_model_preprocess_params)
+    return params # instead of parsing output string
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/test/test_preprocess_params.py
+++ b/test/test_preprocess_params.py
@@ -39,8 +39,7 @@ def run(params: Dict, logger=None):
 
     logger.info("Running preprocessing.") if logger else print(
         "Running preprocessing.")
-
-     ###### Place your code here ########
+    ###### Place your code here ########
 
     logger.debug(f"Loading data from {params['input_dir']}.")
     ###### Place your code here ######
@@ -62,8 +61,6 @@ def main(args):
                                     additional_definitions=test_model_preprocess_params,
                                     required=None
                                     )
-    print(params)
-    print(test_model_preprocess_params)
     return params # instead of parsing output string
 
 

--- a/test/test_train_params.py
+++ b/test/test_train_params.py
@@ -1,0 +1,85 @@
+import sys
+from pathlib import Path
+from typing import Dict
+
+from improvelib.applications.drug_response_prediction.config import DRPTrainConfig
+
+# Global variables
+filepath = Path(__file__).resolve().parent  # [Req]
+
+# Define parameters for the script
+test_model_train_params = [
+        # see argparse.ArgumentParser.add_argument() for more information
+        {
+            # name of the argument
+            "name": "y_data_files",
+            # type of the argument
+            "type": str,
+            # number of arguments that should be consumed
+            "nargs": "+",
+            # help message
+            "help": "List of files that contain the y (prediction variable) data.",
+        },
+        {
+            # name of the argument
+            "name": "supplement",
+            # type of the argument
+            "type": str,
+            # number of arguments that should be consumed
+            "nargs": 2,
+            # name of the argument in usage messages
+            "metavar": ("FILE", "TYPE"),
+            # action to be taken when this argument is encountered
+            "action": "append",
+            # default value of the argument
+            "default": [ ('a' , 'b')],
+            "help": "Supplemental data tuple FILE and TYPE. FILE is in INPUT_DIR.",   # help message
+        }
+    ]
+
+
+# Default functions for all improve scripts are main and run
+# main initializes parameters and calls run with the parameters
+# run is the main function that executes the script or can be imported and used in other scripts
+
+def run(params: Dict, logger=None):
+    """ Run model training.
+
+    Args:
+        params (dict): dict of CANDLE/IMPROVE parameters and parsed values.
+        cfg (Train): Train Config object. Default is None. 
+
+    Returns:
+        str: status of training ("Success.").
+    """
+
+    logger.info("Running model training.") if logger else print(
+        "Running model training.")
+
+     ###### Place your code here ########
+
+    logger.debug(f"Loading data from {params['input_dir']}.")
+    ###### Place your code here ######
+
+    logger.debug(f"Training model.")
+    ###### Place your code here ######
+    
+    logger.info(f"Run completed. Model and results saved in {params['output_dir']}.")
+    return "Success."
+
+
+def main(args):
+    """ Main function for training."""
+    
+    cfg = DRPTrainConfig()
+    params = cfg.initialize_parameters(filepath,
+                                    default_config="test_default_1.cfg",
+                                    # additional_cli_section='My section',
+                                    additional_definitions=test_model_train_params,
+                                    required=None
+                                    )
+    print("Train parameters:", params)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/test/test_train_params.py
+++ b/test/test_train_params.py
@@ -12,28 +12,12 @@ test_model_train_params = [
         # see argparse.ArgumentParser.add_argument() for more information
         {
             # name of the argument
-            "name": "y_data_files",
+            "name": "train_test_var",
             # type of the argument
-            "type": str,
-            # number of arguments that should be consumed
-            "nargs": "+",
+            "type": int,
             # help message
-            "help": "List of files that contain the y (prediction variable) data.",
-        },
-        {
-            # name of the argument
-            "name": "supplement",
-            # type of the argument
-            "type": str,
-            # number of arguments that should be consumed
-            "nargs": 2,
-            # name of the argument in usage messages
-            "metavar": ("FILE", "TYPE"),
-            # action to be taken when this argument is encountered
-            "action": "append",
-            # default value of the argument
-            "default": [ ('a' , 'b')],
-            "help": "Supplemental data tuple FILE and TYPE. FILE is in INPUT_DIR.",   # help message
+            "help": "Test variable for train.",
+            "default": 5,
         }
     ]
 
@@ -55,8 +39,7 @@ def run(params: Dict, logger=None):
 
     logger.info("Running model training.") if logger else print(
         "Running model training.")
-
-     ###### Place your code here ########
+    ###### Place your code here ########
 
     logger.debug(f"Loading data from {params['input_dir']}.")
     ###### Place your code here ######
@@ -78,7 +61,7 @@ def main(args):
                                     additional_definitions=test_model_train_params,
                                     required=None
                                     )
-    print("Train parameters:", params)
+    return params
 
 
 if __name__ == "__main__":

--- a/test/unittest_params.py
+++ b/test/unittest_params.py
@@ -13,6 +13,8 @@ import test_infer_params
 config_file_1='test_default_1.cfg'
 config_file_2='test_default_2.cfg'
 
+# TODO: Number tests? Save param_log_file.txt per test? Check global params?
+
 class TestPreprocessConfigs(unittest.TestCase):
     
     @patch('sys.stdout')
@@ -91,8 +93,37 @@ class TestTrainConfigs(unittest.TestCase):
         self.assertEqual(int(train_params['epochs']), 20, msg=f"Parameter value {train_params['epochs']} does not match the config file value in {config_file_2}.")
         
         
+class TestInferConfigs(unittest.TestCase):   
     
-#class TestInferConfigs(unittest.TestCase):   
-
+    @patch('sys.stdout')
+    def test_infer_default_values(self, mock_stdout):
+        """INFER: Check default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertEqual(infer_params['test_batch'], 64, msg="Parameter value is not the default value.")
+        self.assertTrue(infer_params['infer_test_var'] == "infer", msg="Parameter value is not the default value.")
+        
+    @patch('sys.stdout')
+    def test_infer_config_values(self, mock_stdout):
+        """INFER: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertTrue(infer_params['json_scores_suffix'] == 'test_scores', msg=f"Parameter value {infer_params['json_scores_suffix']} does not match the config file value in {config_file_1}.")
+        
+    @patch('sys.stdout')
+    def test_infer_cli_values(self, mock_stdout):
+        """INFER: Check CLI values of parameters with config_file_1 set as default config file."""
+        sys.argv = ['test_infer_params.py', '--json_scores_suffix', 'test_scores_cli']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertTrue(infer_params['json_scores_suffix'] == 'test_scores_cli', msg=f"Parameter value {infer_params['json_scores_suffix']} does not match the CLI value: test_splits_cli.")
+    
+    @patch('sys.stdout')    
+    def test_infer_nondefault_config_values(self, mock_stdout):
+        """INFER: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertTrue(infer_params['infer_test_var'] == 'test_infer', msg=f"Parameter value {infer_params['infer_test_var']} does not match the config file value in {config_file_2}.")
+        self.assertTrue(infer_params['json_scores_suffix'] == "scores", msg="Parameter value is not the default value.")
+        
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/unittest_params.py
+++ b/test/unittest_params.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch
+import sys
+from io import StringIO
+#import logging
+
+#logging.basicConfig(level=logging.DEBUG)
+
+import test_preprocess_params
+import test_train_params
+import test_infer_params
+
+config_file_1='test_default_1.cfg'
+config_file_2='test_default_2.cfg'
+
+class TestPreprocessConfigs(unittest.TestCase):
+    @patch('sys.stdout')
+    def test_preprocess_default_values(self, mock_stdout):
+        """Check default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertTrue(preprocess_params['x_data_dir'] == 'x_data', msg="Parameter value is not the default value.")
+        self.assertTrue(preprocess_params['y_data_dir'] == 'y_data', msg="Parameter value is not the default value.")
+        
+    @patch('sys.stdout')
+    def test_preprocess_config_values(self, mock_stdout):
+        #with patch('sys.stdout', new=StringIO()) as capture:
+        #sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits']
+        """Check config values of parameters listed in config_file_1 when this file is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        #output = mock_stdout.getvalue().strip()
+        #output = capture.getvalue().strip()
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_1}.")
+        
+    @patch('sys.stdout')
+    def test_preprocess_cli_values(self, mock_stdout):
+        """Check CLI values of parameters with config_file_1 set as default config file."""
+        sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits_cli']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        #output = mock_stdout.getvalue().strip()
+        #output = capture.getvalue().strip()
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_cli', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the CLI value: test_splits_cli.")
+    
+    @patch('sys.stdout')    
+    def test_preprocess_nondefault_config_values(self, mock_stdout):
+        """Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'prep', msg="Parameter value is not the default value.") 
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_b', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_2}.")
+        
+#class TestTrainConfigs(unittest.TestCase):
+    
+#class TestInferConfigs(unittest.TestCase):   
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/unittest_params.py
+++ b/test/unittest_params.py
@@ -14,9 +14,10 @@ config_file_1='test_default_1.cfg'
 config_file_2='test_default_2.cfg'
 
 class TestPreprocessConfigs(unittest.TestCase):
+    
     @patch('sys.stdout')
     def test_preprocess_default_values(self, mock_stdout):
-        """Check default values of parameters when config_file_1 is set as default config file."""
+        """PREPROCESS: Check default values of parameters when config_file_1 is set as default config file."""
         sys.argv = ['test_preprocess_params.py']
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertTrue(preprocess_params['x_data_dir'] == 'x_data', msg="Parameter value is not the default value.")
@@ -26,7 +27,7 @@ class TestPreprocessConfigs(unittest.TestCase):
     def test_preprocess_config_values(self, mock_stdout):
         #with patch('sys.stdout', new=StringIO()) as capture:
         #sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits']
-        """Check config values of parameters listed in config_file_1 when this file is set as default config file."""
+        """PREPROCESS: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
         sys.argv = ['test_preprocess_params.py']
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
         #output = mock_stdout.getvalue().strip()
@@ -36,7 +37,7 @@ class TestPreprocessConfigs(unittest.TestCase):
         
     @patch('sys.stdout')
     def test_preprocess_cli_values(self, mock_stdout):
-        """Check CLI values of parameters with config_file_1 set as default config file."""
+        """PREPROCESS: Check CLI values of parameters with config_file_1 set as default config file."""
         sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits_cli']
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
         #output = mock_stdout.getvalue().strip()
@@ -46,13 +47,50 @@ class TestPreprocessConfigs(unittest.TestCase):
     
     @patch('sys.stdout')    
     def test_preprocess_nondefault_config_values(self, mock_stdout):
-        """Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
         sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertTrue(preprocess_params['preprocess_test_var'] == 'prep', msg="Parameter value is not the default value.") 
         self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_b', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_2}.")
         
-#class TestTrainConfigs(unittest.TestCase):
+class TestTrainConfigs(unittest.TestCase):
+    
+    @patch('sys.stdout')
+    def test_train_default_values(self, mock_stdout):
+        """TRAIN: Check default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertEqual(train_params['epochs'], 7, msg="Parameter value is not the default value.")
+        self.assertEqual(train_params['learning_rate'], 7, msg="Parameter value is not the default value.")
+        
+    @patch('sys.stdout')
+    def test_train_config_values(self, mock_stdout):
+        """TRAIN: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        # TODO: Check why train_test_var is string value
+        self.assertEqual(int(train_params['train_test_var']), 10, msg=f"Parameter value {train_params['train_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertTrue(train_params['model_file_name'] == 'test_model', msg=f"Parameter value {train_params['model_file_name']} does not match the config file value in {config_file_1}.")
+        
+    @patch('sys.stdout')
+    def test_train_cli_values(self, mock_stdout):
+        """TRAIN: Check CLI values of parameters with config_file_1 set as default config file."""
+        sys.argv = ['test_train_params.py', '--batch_size', '40']
+        train_params = test_train_params.main(sys.argv[1:])
+        # TODO: Check why train_test_var is string value
+        self.assertEqual(int(train_params['train_test_var']), 10, msg=f"Parameter value {train_params['train_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertEqual(train_params['batch_size'], 40, msg=f"Parameter value {train_params['batch_size']} does not match the CLI value: test_splits_cli.")
+    
+    @patch('sys.stdout')    
+    def test_train_nondefault_config_values(self, mock_stdout):
+        """TRAIN: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2]
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertEqual(int(train_params['train_test_var']), 5, msg="Parameter value is not the default value.") 
+        # TODO: Check why epochs is string value
+        self.assertEqual(int(train_params['epochs']), 20, msg=f"Parameter value {train_params['epochs']} does not match the config file value in {config_file_2}.")
+        
+        
     
 #class TestInferConfigs(unittest.TestCase):   
 

--- a/tests/test_default_1.cfg
+++ b/tests/test_default_1.cfg
@@ -1,0 +1,10 @@
+[Preprocess]
+splits_dir=test_splits
+preprocess_test_var=preprocess
+
+[Train]
+train_test_var=10
+model_file_name=test_model
+
+[Infer]
+json_scores_suffix=test_scores

--- a/tests/test_default_2.cfg
+++ b/tests/test_default_2.cfg
@@ -1,6 +1,6 @@
 [Preprocess]
 splits_dir=test_splits_b
-preprocess_test_var=ic50
+variable_name=test
 split=[2,3]
 only_cross_study=True
 study_number=2
@@ -8,6 +8,16 @@ train_percent=0.75
 
 [Train]
 epochs=20
+variable_name=test
+split=[2,3]
+only_cross_study=True
+study_number=2
+train_percent=0.75
 
 [Infer]
 infer_test_var=test_infer
+variable_name=test
+split=[2,3]
+only_cross_study=True
+study_number=2
+train_percent=0.75

--- a/tests/test_default_2.cfg
+++ b/tests/test_default_2.cfg
@@ -1,0 +1,13 @@
+[Preprocess]
+splits_dir=test_splits_b
+preprocess_test_var=ic50
+split=[2,3]
+only_cross_study=True
+study_number=2
+train_percent=0.75
+
+[Train]
+epochs=20
+
+[Infer]
+infer_test_var=test_infer

--- a/tests/test_infer_params.py
+++ b/tests/test_infer_params.py
@@ -2,20 +2,20 @@ import sys
 from pathlib import Path
 from typing import Dict
 
-from improvelib.applications.drug_response_prediction.config import DRPPreprocessConfig
+from improvelib.applications.drug_response_prediction.config import DRPInferConfig
 
 # Global variables
 filepath = Path(__file__).resolve().parent  # [Req]
 
 # Define parameters for the script
-test_model_preprocess_params = [
+test_model_infer_params = [
         {
-            "name": "preprocess_test_var",
+            "name": "infer_test_var",
             "type": str,
-            "help": "Test variable for preprocess.",
-            "default": "prep",
+            "help": "Test variable for infer.",
+            "default": "infer",
         },
-        {   
+                {   
             "name": "split",
             "type": list,
             "default": ['0'],
@@ -43,12 +43,12 @@ test_model_preprocess_params = [
     ]
 
 def main(args):
-    """ Main function for preprocessing."""
+    """ Main function for inference."""
     
-    cfg = DRPPreprocessConfig()
+    cfg = DRPInferConfig()
     params = cfg.initialize_parameters(filepath,
                                     default_config="test_default_1.cfg",
-                                    additional_definitions=test_model_preprocess_params,
+                                    additional_definitions=test_model_infer_params,
                                     required=None
                                     )
     return params

--- a/tests/test_preprocess_params.py
+++ b/tests/test_preprocess_params.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+from typing import Dict
+
+from improvelib.applications.drug_response_prediction.config import DRPPreprocessConfig
+
+# Global variables
+filepath = Path(__file__).resolve().parent  # [Req]
+
+# Define parameters for the script
+test_model_preprocess_params = [
+        # see argparse.ArgumentParser.add_argument() for more information
+        {
+            # name of the argument
+            "name": "preprocess_test_var",
+            # type of the argument
+            "type": str,
+            # help message
+            "help": "Test variable for preprocess.",
+            "default": "prep", # must include default, otherwise not defined
+        },
+        {   
+            "name": "split",
+            "type": list,
+            "default": ['0'],
+            "help": "Split number for preprocessing"
+        },
+        {
+            "name": "only_cross_study",
+            "type": bool,
+            "default": False,
+        },
+        {
+            "name": "study_number",
+            "type": int,
+            "default": 1,
+        },
+        {
+            "name": "train_percent",
+            "type": float,
+            "default": 0.8,
+        },
+    ]
+
+
+# Default functions for all improve scripts are main and run
+# main initializes parameters and calls run with the parameters
+# run is the main function that executes the script or can be imported and used in other scripts
+'''
+def run(params: Dict, logger=None):
+    """ Run data preprocessing.
+
+    Args:
+        params (dict): dict of CANDLE/IMPROVE parameters and parsed values.
+        cfg (Preprocess): Preprocess Config object. Default is None. 
+
+    Returns:
+        str: status of preprocessing ("Success.").
+    """
+
+    #logger.info("Running preprocessing.") if logger else print(
+    #    "Running preprocessing.")
+    ###### Place your code here ########
+
+    #logger.debug(f"Loading data from {params['input_dir']}.")
+    ###### Place your code here ######
+
+    #logger.debug(f"Creating data from {params['input_dir']}.")
+    ###### Place your code here ######
+    
+    #logger.info(f"Run completed. Data saved in {params['output_dir']}.")
+    return "Success."
+'''
+
+def main(args):
+    """ Main function for preprocessing."""
+    
+    cfg = DRPPreprocessConfig()
+    params = cfg.initialize_parameters(filepath,
+                                    default_config="test_default_1.cfg",
+                                    # additional_cli_section='My section',
+                                    additional_definitions=test_model_preprocess_params,
+                                    required=None
+                                    )
+    return params # instead of parsing output string
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tests/test_train_params.py
+++ b/tests/test_train_params.py
@@ -2,18 +2,18 @@ import sys
 from pathlib import Path
 from typing import Dict
 
-from improvelib.applications.drug_response_prediction.config import DRPPreprocessConfig
+from improvelib.applications.drug_response_prediction.config import DRPTrainConfig
 
 # Global variables
 filepath = Path(__file__).resolve().parent  # [Req]
 
 # Define parameters for the script
-test_model_preprocess_params = [
+test_model_train_params = [
         {
-            "name": "preprocess_test_var",
-            "type": str,
-            "help": "Test variable for preprocess.",
-            "default": "prep",
+            "name": "train_test_var",
+            "type": int,
+            "help": "Test variable for train.",
+            "default": 5,
         },
         {   
             "name": "split",
@@ -42,13 +42,14 @@ test_model_preprocess_params = [
         },
     ]
 
+
 def main(args):
-    """ Main function for preprocessing."""
+    """ Main function for training."""
     
-    cfg = DRPPreprocessConfig()
+    cfg = DRPTrainConfig()
     params = cfg.initialize_parameters(filepath,
                                     default_config="test_default_1.cfg",
-                                    additional_definitions=test_model_preprocess_params,
+                                    additional_definitions=test_model_train_params,
                                     required=None
                                     )
     return params

--- a/tests/unittest_params.py
+++ b/tests/unittest_params.py
@@ -3,11 +3,8 @@ from unittest.mock import patch
 import sys
 from io import StringIO
 from pathlib import Path
-#import logging
 
-#logging.basicConfig(level=logging.DEBUG)
-
-# Global variables
+# global variables
 filepath = Path(__file__).resolve().parent  # [Req]
 
 import test_preprocess_params
@@ -18,209 +15,418 @@ import test_infer_params
 config_file_1=str(filepath) + '/test_default_1.cfg'
 config_file_2=str(filepath) + '/test_default_2.cfg'
 
-# TODO: Number tests? Save param_log_file.txt per test? Check global params?
-
 class TestOrderPreprocessConfigs(unittest.TestCase):
     
-    @patch('sys.stdout')
-    def test_preprocess_default_values(self, mock_stdout):
+    """Tests to check that the parameters are read in this order for PREPROCESS: CLI, config file, default.""" 
+       
+    def test_preprocess_default_values(self):
         """PREPROCESS: Check default values of parameters when config_file_1 is set as default config file."""
         sys.argv = ['test_preprocess_params.py']
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertTrue(preprocess_params['x_data_dir'] == 'x_data', msg="Parameter value is not the default value.")
         self.assertTrue(preprocess_params['y_data_dir'] == 'y_data', msg="Parameter value is not the default value.")
         
-    @patch('sys.stdout')
-    def test_preprocess_config_values(self, mock_stdout):
-        #with patch('sys.stdout', new=StringIO()) as capture:
-        #sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits']
+    def test_preprocess_config_values(self):
         """PREPROCESS: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
         sys.argv = ['test_preprocess_params.py']
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        #output = mock_stdout.getvalue().strip()
-        #output = capture.getvalue().strip()
         self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
         self.assertTrue(preprocess_params['splits_dir'] == 'test_splits', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_1}.")
         
-    @patch('sys.stdout')
-    def test_preprocess_cli_values(self, mock_stdout):
+    def test_preprocess_cli_values(self):
         """PREPROCESS: Check CLI values of parameters with config_file_1 set as default config file."""
         sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits_cli']
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        #output = mock_stdout.getvalue().strip()
-        #output = capture.getvalue().strip()
         self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
         self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_cli', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the CLI value: test_splits_cli.")
-    
-    @patch('sys.stdout')    
-    def test_preprocess_nondefault_config_values(self, mock_stdout):
+        
+    def test_preprocess_nondefault_config_values(self):
         """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
         sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
         preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertTrue(preprocess_params['preprocess_test_var'] == 'prep', msg="Parameter value is not the default value.") 
         self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_b', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_2}.")
         
+    def test_preprocess_nondefault_config_and_cli_values(self):
+        """PREPROCESS: Check CLI values of parameters when using non-default config file, config_file_2."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2, '--variable_name', 'cli_test']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'prep', msg="Parameter value is not the default value.") 
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_b', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_2}.")
+        self.assertTrue(preprocess_params['variable_name'] == 'cli_test', msg=f"Parameter value {preprocess_params['variable_name']} does not match the CLI value: cli_test.")
+        
 class TestOrderTrainConfigs(unittest.TestCase):
     
-    @patch('sys.stdout')
-    def test_train_default_values(self, mock_stdout):
+    """Tests to check that the parameters are read in this order for TRAIN: CLI, config file, default.""" 
+    
+    def test_train_default_values(self):
         """TRAIN: Check default values of parameters when config_file_1 is set as default config file."""
         sys.argv = ['test_train_params.py']
         train_params = test_train_params.main(sys.argv[1:])
         self.assertEqual(train_params['epochs'], 7, msg="Parameter value is not the default value.")
         self.assertEqual(train_params['learning_rate'], 7, msg="Parameter value is not the default value.")
         
-    @patch('sys.stdout')
-    def test_train_config_values(self, mock_stdout):
+    def test_train_config_values(self):
         """TRAIN: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
         sys.argv = ['test_train_params.py']
         train_params = test_train_params.main(sys.argv[1:])
-        # TODO: Check why train_test_var is string value
         self.assertEqual(train_params['train_test_var'], 10, msg=f"Parameter value {train_params['train_test_var']} does not match the config file value in {config_file_1}.")
         self.assertTrue(train_params['model_file_name'] == 'test_model', msg=f"Parameter value {train_params['model_file_name']} does not match the config file value in {config_file_1}.")
         
-    @patch('sys.stdout')
-    def test_train_cli_values(self, mock_stdout):
+    def test_train_cli_values(self):
         """TRAIN: Check CLI values of parameters with config_file_1 set as default config file."""
         sys.argv = ['test_train_params.py', '--batch_size', '40']
         train_params = test_train_params.main(sys.argv[1:])
-        # TODO: Check why train_test_var is string value
         self.assertEqual(train_params['train_test_var'], 10, msg=f"Parameter value {train_params['train_test_var']} does not match the config file value in {config_file_1}.")
         self.assertEqual(train_params['batch_size'], 40, msg=f"Parameter value {train_params['batch_size']} does not match the CLI value: test_splits_cli.")
-    
-    @patch('sys.stdout')    
-    def test_train_nondefault_config_values(self, mock_stdout):
+      
+    def test_train_nondefault_config_values(self):
         """TRAIN: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
         sys.argv = ['test_train_params.py', '--config_file', config_file_2]
         train_params = test_train_params.main(sys.argv[1:])
         self.assertEqual(train_params['train_test_var'], 5, msg="Parameter value is not the default value.") 
-        # TODO: Check why epochs is string value
         self.assertEqual(train_params['epochs'], 20, msg=f"Parameter value {train_params['epochs']} does not match the config file value in {config_file_2}.")
         
-        
+    def test_train_nondefault_config_and_cli_values(self):
+        """TRAIN: Check CLI values of parameters when using non-default config file, config_file_2."""
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2, '--variable_name', 'cli_test']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertTrue(train_params['train_test_var'] == 'prep', msg="Parameter value is not the default value.") 
+        self.assertTrue(train_params['splits_dir'] == 'test_splits_b', msg=f"Parameter value {train_params['splits_dir']} does not match the config file value in {config_file_2}.")
+        self.assertTrue(train_params['variable_name'] == 'cli_test', msg=f"Parameter value {train_params['variable_name']} does not match the CLI value: cli_test.")    
+
 class TestOrderInferConfigs(unittest.TestCase):   
     
-    @patch('sys.stdout')
-    def test_infer_default_values(self, mock_stdout):
+    """Tests to check that the parameters are read in this order for INFER: CLI, config file, default.""" 
+    
+    def test_infer_default_values(self):
         """INFER: Check default values of parameters when config_file_1 is set as default config file."""
         sys.argv = ['test_infer_params.py']
         infer_params = test_infer_params.main(sys.argv[1:])
         self.assertEqual(infer_params['test_batch'], 64, msg="Parameter value is not the default value.")
         self.assertTrue(infer_params['infer_test_var'] == "infer", msg="Parameter value is not the default value.")
         
-    @patch('sys.stdout')
-    def test_infer_config_values(self, mock_stdout):
+    def test_infer_config_values(self):
         """INFER: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
         sys.argv = ['test_infer_params.py']
         infer_params = test_infer_params.main(sys.argv[1:])
         self.assertTrue(infer_params['json_scores_suffix'] == 'test_scores', msg=f"Parameter value {infer_params['json_scores_suffix']} does not match the config file value in {config_file_1}.")
         
-    @patch('sys.stdout')
-    def test_infer_cli_values(self, mock_stdout):
+    def test_infer_cli_values(self):
         """INFER: Check CLI values of parameters with config_file_1 set as default config file."""
         sys.argv = ['test_infer_params.py', '--json_scores_suffix', 'test_scores_cli']
         infer_params = test_infer_params.main(sys.argv[1:])
         self.assertTrue(infer_params['json_scores_suffix'] == 'test_scores_cli', msg=f"Parameter value {infer_params['json_scores_suffix']} does not match the CLI value: test_splits_cli.")
     
-    @patch('sys.stdout')    
-    def test_infer_nondefault_config_values(self, mock_stdout):
+    def test_infer_nondefault_config_values(self):
         """INFER: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
         sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
         infer_params = test_infer_params.main(sys.argv[1:])
         self.assertTrue(infer_params['infer_test_var'] == 'test_infer', msg=f"Parameter value {infer_params['infer_test_var']} does not match the config file value in {config_file_2}.")
         self.assertTrue(infer_params['json_scores_suffix'] == "scores", msg="Parameter value is not the default value.")
 
+    def test_infer_nondefault_config_and_cli_values(self):
+        """INFER: Check CLI values of parameters when using non-default config file, config_file_2."""
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2, '--variable_name', 'cli_test']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertTrue(infer_params['infer_test_var'] == 'prep', msg="Parameter value is not the default value.") 
+        self.assertTrue(infer_params['splits_dir'] == 'test_splits_b', msg=f"Parameter value {infer_params['splits_dir']} does not match the config file value in {config_file_2}.")
+        self.assertTrue(infer_params['variable_name'] == 'cli_test', msg=f"Parameter value {infer_params['variable_name']} does not match the CLI value: cli_test.")
+
 class TestTypePreprocessConfigs(unittest.TestCase):
     
-    @patch('sys.stdout')
-    def test_preprocess_default_type_string(self):
-        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
-        sys.argv = ['test_preprocess_params.py']
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['splits_dir'], str)
-        
-    def test_preprocess_default_type_list(self, mock_stdout):
-        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
-        sys.argv = ['test_preprocess_params.py']
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['split'], list)
-        
-    def test_preprocess_default_type_boolean(self, mock_stdout):
-        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
-        sys.argv = ['test_preprocess_params.py']
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['only_cross_study'], bool)
-        
-    def test_preprocess_default_type_integer(self, mock_stdout):
-        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
-        sys.argv = ['test_preprocess_params.py']
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['study_number'], int)
-        
-    def test_preprocess_default_type_float(self, mock_stdout):
-        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
-        sys.argv = ['test_preprocess_params.py']
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['train_percent'], float)
-  
-    @patch('sys.stdout')    
-    def test_preprocess_config_type_string(self, mock_stdout):
-        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
-        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['splits_dir'], str)
-        
-    @patch('sys.stdout')    
-    def test_preprocess_config_type_list(self, mock_stdout):
-        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
-        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['split'], list)
-        
-    @patch('sys.stdout')    
-    def test_preprocess_config_type_boolean(self, mock_stdout):
-        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
-        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['only_cross_study'], bool)
-  
-    @patch('sys.stdout')    
-    def test_preprocess_config_type_integer(self, mock_stdout):
-        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
-        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['study_number'], int)
-        
-    @patch('sys.stdout')    
-    def test_preprocess_config_type_float(self, mock_stdout):
-        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
-        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        self.assertIsInstance(preprocess_params['train_percent'], float)
-
-    '''        
-    @patch('sys.stdout')
-    def test_preprocess_cli_values(self, mock_stdout):
-        """PREPROCESS: Check CLI values of parameters with config_file_1 set as default config file."""
-        sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits_cli']
-        preprocess_params = test_preprocess_params.main(sys.argv[1:])
-        #output = mock_stdout.getvalue().strip()
-        #output = capture.getvalue().strip()
-        self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
-        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_cli', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the CLI value: test_splits_cli.")
+    """Check types when parameters are set as default."""
     
-    @patch('sys.stdout')    
-    def test_preprocess_config_type(self, mock_stdout):
-        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
-        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
-        self.assertIsInstance(preprocess_params['preprocess_test_var'], str)
+    def test_preprocess_default_type_string(self):
+        """PREPROCESS: Check type for string parameter."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['variable_name'], str)
+        
+    def test_preprocess_default_type_list(self):
+        """PREPROCESS: Check type for list parameter"""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertIsInstance(preprocess_params['split'], list)
+        
+    def test_preprocess_default_type_boolean(self):
+        """PREPROCESS: Check type for boolean parameter."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertIsInstance(preprocess_params['only_cross_study'], bool)
+        
+    def test_preprocess_default_type_integer(self):
+        """PREPROCESS: Check type for integer parameter."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertIsInstance(preprocess_params['study_number'], int)
+        
+    def test_preprocess_default_type_float(self):
+        """PREPROCESS: Check type for float parameter."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
         self.assertIsInstance(preprocess_params['train_percent'], float)
-    '''
+        
+    """Check types when parameters are set as in the config file."""
+  
+    def test_preprocess_config_type_string(self):
+        """PREPROCESS: Check type for string parameter in config_file_2."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['variable_name'], str)
+             
+    def test_preprocess_config_type_list(self):
+        """PREPROCESS: Check type for list parameter in config_file_2."""        
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['split'], list)
+        
+    def test_preprocess_config_type_boolean(self):
+        """PREPROCESS: Check type for boolean parameter in config_file_2."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['only_cross_study'], bool)
+   
+    def test_preprocess_config_type_integer(self):
+        """PREPROCESS: Check type for integer parameter in config_file_2."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['study_number'], int)
+        
+    def test_preprocess_config_type_float(self):
+        """PREPROCESS: Check type for float parameter in config_file_2."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['train_percent'], float)
 
+    """Check types when parameters are set on the command line."""
+    
+    def test_preprocess_cli_type_string(self):
+        """PREPROCESS: Check type for string parameter when set on the command line."""
+        sys.argv = ['test_preprocess_params.py', '--variable_name', 'cli_test']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['variable_name'], str)
+             
+    def test_preprocess_cli_type_list(self):
+        """PREPROCESS: Check type for list parameter when set on the command line."""        
+        sys.argv = ['test_preprocess_params.py', '--split', '[4,5]']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['split'], list)
+        
+    def test_preprocess_cli_type_boolean(self):
+        """PREPROCESS: Check type for boolean parameter when set on the command line."""
+        sys.argv = ['test_preprocess_params.py', '--only_cross_study', 'True']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['only_cross_study'], bool)
+   
+    def test_preprocess_cli_type_integer(self):
+        """PREPROCESS: Check type for integer parameter when set on the command line."""
+        sys.argv = ['test_preprocess_params.py', '--study_number', '4']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['study_number'], int)
+        
+    def test_preprocess_cli_type_float(self):
+        """PREPROCESS: Check type for float parameter when set on the command line."""
+        sys.argv = ['test_preprocess_params.py', '--train_percent', '0.9']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['train_percent'], float) 
+        
+class TestTypeTrainConfigs(unittest.TestCase):
+    
+    """Check types when parameters are set as default."""
+    
+    def test_train_default_type_string(self):
+        """TRAIN: Check type for string parameter."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['variable_name'], str)
+        
+    def test_train_default_type_list(self):
+        """TRAIN: Check type for list parameter"""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['split'], list)
+        
+    def test_train_default_type_boolean(self):
+        """TRAIN: Check type for boolean parameter."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['only_cross_study'], bool)
+        
+    def test_train_default_type_integer(self):
+        """TRAIN: Check type for integer parameter."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['study_number'], int)
+        
+    def test_train_default_type_float(self):
+        """TRAIN: Check type for float parameter."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['train_percent'], float)
+        
+    """Check types when parameters are set as in the config file."""
+  
+    def test_train_config_type_string(self):
+        """TRAIN: Check type for string parameter in config_file_2."""
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2]
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['variable_name'], str)
+             
+    def test_train_config_type_list(self):
+        """TRAIN: Check type for list parameter in config_file_2."""        
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2]
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['split'], list)
+        
+    def test_train_config_type_boolean(self):
+        """TRAIN: Check type for boolean parameter in config_file_2."""
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2]
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['only_cross_study'], bool)
+   
+    def test_train_config_type_integer(self):
+        """TRAIN: Check type for integer parameter in config_file_2."""
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2]
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['study_number'], int)
+        
+    def test_train_config_type_float(self):
+        """TRAIN: Check type for float parameter in config_file_2."""
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2]
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['train_percent'], float)
 
-       
+    """Check types when parameters are set on the command line."""
+    
+    def test_train_cli_type_string(self):
+        """TRAIN: Check type for string parameter when set on the command line."""
+        sys.argv = ['test_train_params.py', '--variable_name', 'cli_test']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['variable_name'], str)
+             
+    def test_train_cli_type_list(self):
+        """TRAIN: Check type for list parameter when set on the command line."""        
+        sys.argv = ['test_train_params.py', '--split', '[4,5]']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['split'], list)
+        
+    def test_train_cli_type_boolean(self):
+        """TRAIN: Check type for boolean parameter when set on the command line."""
+        sys.argv = ['test_train_params.py', '--only_cross_study', 'True']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['only_cross_study'], bool)
+   
+    def test_train_cli_type_integer(self):
+        """TRAIN: Check type for integer parameter when set on the command line."""
+        sys.argv = ['test_train_params.py', '--study_number', '4']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['study_number'], int)
+        
+    def test_train_cli_type_float(self):
+        """TRAIN: Check type for float parameter when set on the command line."""
+        sys.argv = ['test_train_params.py', '--train_percent', '0.9']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertIsInstance(train_params['train_percent'], float)
+        
+class TestTypeInferConfigs(unittest.TestCase):
+    
+    """Check types when parameters are set as default."""
+    
+    def test_infer_default_type_string(self):
+        """INFER: Check type for string parameter."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['variable_name'], str)
+        
+    def test_infer_default_type_list(self):
+        """INFER: Check type for list parameter"""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['split'], list)
+        
+    def test_infer_default_type_boolean(self):
+        """INFER: Check type for boolean parameter."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['only_cross_study'], bool)
+        
+    def test_infer_default_type_integer(self):
+        """INFER: Check type for integer parameter."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['study_number'], int)
+        
+    def test_infer_default_type_float(self):
+        """INFER: Check type for float parameter."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['train_percent'], float)
+        
+    """Check types when parameters are set as in the config file."""
+  
+    def test_infer_config_type_string(self):
+        """INFER: Check type for string parameter in config_file_2."""
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['variable_name'], str)
+             
+    def test_infer_config_type_list(self):
+        """INFER: Check type for list parameter in config_file_2."""        
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['split'], list)
+        
+    def test_infer_config_type_boolean(self):
+        """INFER: Check type for boolean parameter in config_file_2."""
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['only_cross_study'], bool)
+   
+    def test_infer_config_type_integer(self):
+        """INFER: Check type for integer parameter in config_file_2."""
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['study_number'], int)
+        
+    def test_infer_config_type_float(self):
+        """INFER: Check type for float parameter in config_file_2."""
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['train_percent'], float)
+
+    """Check types when parameters are set on the command line."""
+    
+    def test_infer_cli_type_string(self):
+        """INFER: Check type for string parameter when set on the command line."""
+        sys.argv = ['test_infer_params.py', '--variable_name', 'cli_test']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['variable_name'], str)
+             
+    def test_infer_cli_type_list(self):
+        """INFER: Check type for list parameter when set on the command line."""        
+        sys.argv = ['test_infer_params.py', '--split', '[4,5]']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['split'], list)
+        
+    def test_infer_cli_type_boolean(self):
+        """INFER: Check type for boolean parameter when set on the command line."""
+        sys.argv = ['test_infer_params.py', '--only_cross_study', 'True']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['only_cross_study'], bool)
+   
+    def test_infer_cli_type_integer(self):
+        """INFER: Check type for integer parameter when set on the command line."""
+        sys.argv = ['test_infer_params.py', '--study_number', '4']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['study_number'], int)
+        
+    def test_infer_cli_type_float(self):
+        """INFER: Check type for float parameter when set on the command line."""
+        sys.argv = ['test_infer_params.py', '--train_percent', '0.9']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertIsInstance(infer_params['train_percent'], float)
+              
+     
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/unittest_params.py
+++ b/tests/unittest_params.py
@@ -1,0 +1,226 @@
+import unittest
+from unittest.mock import patch
+import sys
+from io import StringIO
+from pathlib import Path
+#import logging
+
+#logging.basicConfig(level=logging.DEBUG)
+
+# Global variables
+filepath = Path(__file__).resolve().parent  # [Req]
+
+import test_preprocess_params
+import test_train_params
+import test_infer_params
+
+# set paths to test config files
+config_file_1=str(filepath) + '/test_default_1.cfg'
+config_file_2=str(filepath) + '/test_default_2.cfg'
+
+# TODO: Number tests? Save param_log_file.txt per test? Check global params?
+
+class TestOrderPreprocessConfigs(unittest.TestCase):
+    
+    @patch('sys.stdout')
+    def test_preprocess_default_values(self, mock_stdout):
+        """PREPROCESS: Check default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertTrue(preprocess_params['x_data_dir'] == 'x_data', msg="Parameter value is not the default value.")
+        self.assertTrue(preprocess_params['y_data_dir'] == 'y_data', msg="Parameter value is not the default value.")
+        
+    @patch('sys.stdout')
+    def test_preprocess_config_values(self, mock_stdout):
+        #with patch('sys.stdout', new=StringIO()) as capture:
+        #sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits']
+        """PREPROCESS: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        #output = mock_stdout.getvalue().strip()
+        #output = capture.getvalue().strip()
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_1}.")
+        
+    @patch('sys.stdout')
+    def test_preprocess_cli_values(self, mock_stdout):
+        """PREPROCESS: Check CLI values of parameters with config_file_1 set as default config file."""
+        sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits_cli']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        #output = mock_stdout.getvalue().strip()
+        #output = capture.getvalue().strip()
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_cli', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the CLI value: test_splits_cli.")
+    
+    @patch('sys.stdout')    
+    def test_preprocess_nondefault_config_values(self, mock_stdout):
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'prep', msg="Parameter value is not the default value.") 
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_b', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the config file value in {config_file_2}.")
+        
+class TestOrderTrainConfigs(unittest.TestCase):
+    
+    @patch('sys.stdout')
+    def test_train_default_values(self, mock_stdout):
+        """TRAIN: Check default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertEqual(train_params['epochs'], 7, msg="Parameter value is not the default value.")
+        self.assertEqual(train_params['learning_rate'], 7, msg="Parameter value is not the default value.")
+        
+    @patch('sys.stdout')
+    def test_train_config_values(self, mock_stdout):
+        """TRAIN: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
+        sys.argv = ['test_train_params.py']
+        train_params = test_train_params.main(sys.argv[1:])
+        # TODO: Check why train_test_var is string value
+        self.assertEqual(train_params['train_test_var'], 10, msg=f"Parameter value {train_params['train_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertTrue(train_params['model_file_name'] == 'test_model', msg=f"Parameter value {train_params['model_file_name']} does not match the config file value in {config_file_1}.")
+        
+    @patch('sys.stdout')
+    def test_train_cli_values(self, mock_stdout):
+        """TRAIN: Check CLI values of parameters with config_file_1 set as default config file."""
+        sys.argv = ['test_train_params.py', '--batch_size', '40']
+        train_params = test_train_params.main(sys.argv[1:])
+        # TODO: Check why train_test_var is string value
+        self.assertEqual(train_params['train_test_var'], 10, msg=f"Parameter value {train_params['train_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertEqual(train_params['batch_size'], 40, msg=f"Parameter value {train_params['batch_size']} does not match the CLI value: test_splits_cli.")
+    
+    @patch('sys.stdout')    
+    def test_train_nondefault_config_values(self, mock_stdout):
+        """TRAIN: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_train_params.py', '--config_file', config_file_2]
+        train_params = test_train_params.main(sys.argv[1:])
+        self.assertEqual(train_params['train_test_var'], 5, msg="Parameter value is not the default value.") 
+        # TODO: Check why epochs is string value
+        self.assertEqual(train_params['epochs'], 20, msg=f"Parameter value {train_params['epochs']} does not match the config file value in {config_file_2}.")
+        
+        
+class TestOrderInferConfigs(unittest.TestCase):   
+    
+    @patch('sys.stdout')
+    def test_infer_default_values(self, mock_stdout):
+        """INFER: Check default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertEqual(infer_params['test_batch'], 64, msg="Parameter value is not the default value.")
+        self.assertTrue(infer_params['infer_test_var'] == "infer", msg="Parameter value is not the default value.")
+        
+    @patch('sys.stdout')
+    def test_infer_config_values(self, mock_stdout):
+        """INFER: Check config values of parameters listed in config_file_1 when this file is set as default config file."""
+        sys.argv = ['test_infer_params.py']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertTrue(infer_params['json_scores_suffix'] == 'test_scores', msg=f"Parameter value {infer_params['json_scores_suffix']} does not match the config file value in {config_file_1}.")
+        
+    @patch('sys.stdout')
+    def test_infer_cli_values(self, mock_stdout):
+        """INFER: Check CLI values of parameters with config_file_1 set as default config file."""
+        sys.argv = ['test_infer_params.py', '--json_scores_suffix', 'test_scores_cli']
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertTrue(infer_params['json_scores_suffix'] == 'test_scores_cli', msg=f"Parameter value {infer_params['json_scores_suffix']} does not match the CLI value: test_splits_cli.")
+    
+    @patch('sys.stdout')    
+    def test_infer_nondefault_config_values(self, mock_stdout):
+        """INFER: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_infer_params.py', '--config_file', config_file_2]
+        infer_params = test_infer_params.main(sys.argv[1:])
+        self.assertTrue(infer_params['infer_test_var'] == 'test_infer', msg=f"Parameter value {infer_params['infer_test_var']} does not match the config file value in {config_file_2}.")
+        self.assertTrue(infer_params['json_scores_suffix'] == "scores", msg="Parameter value is not the default value.")
+
+class TestTypePreprocessConfigs(unittest.TestCase):
+    
+    @patch('sys.stdout')
+    def test_preprocess_default_type_string(self):
+        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['splits_dir'], str)
+        
+    def test_preprocess_default_type_list(self, mock_stdout):
+        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['split'], list)
+        
+    def test_preprocess_default_type_boolean(self, mock_stdout):
+        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['only_cross_study'], bool)
+        
+    def test_preprocess_default_type_integer(self, mock_stdout):
+        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['study_number'], int)
+        
+    def test_preprocess_default_type_float(self, mock_stdout):
+        """PREPROCESS: Check type of default values of parameters when config_file_1 is set as default config file."""
+        sys.argv = ['test_preprocess_params.py']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['train_percent'], float)
+  
+    @patch('sys.stdout')    
+    def test_preprocess_config_type_string(self, mock_stdout):
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['splits_dir'], str)
+        
+    @patch('sys.stdout')    
+    def test_preprocess_config_type_list(self, mock_stdout):
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['split'], list)
+        
+    @patch('sys.stdout')    
+    def test_preprocess_config_type_boolean(self, mock_stdout):
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['only_cross_study'], bool)
+  
+    @patch('sys.stdout')    
+    def test_preprocess_config_type_integer(self, mock_stdout):
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['study_number'], int)
+        
+    @patch('sys.stdout')    
+    def test_preprocess_config_type_float(self, mock_stdout):
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        self.assertIsInstance(preprocess_params['train_percent'], float)
+
+    '''        
+    @patch('sys.stdout')
+    def test_preprocess_cli_values(self, mock_stdout):
+        """PREPROCESS: Check CLI values of parameters with config_file_1 set as default config file."""
+        sys.argv = ['test_preprocess_params.py', '--splits_dir', 'test_splits_cli']
+        preprocess_params = test_preprocess_params.main(sys.argv[1:])
+        #output = mock_stdout.getvalue().strip()
+        #output = capture.getvalue().strip()
+        self.assertTrue(preprocess_params['preprocess_test_var'] == 'preprocess', msg=f"Parameter value {preprocess_params['preprocess_test_var']} does not match the config file value in {config_file_1}.")
+        self.assertTrue(preprocess_params['splits_dir'] == 'test_splits_cli', msg=f"Parameter value {preprocess_params['splits_dir']} does not match the CLI value: test_splits_cli.")
+    
+    @patch('sys.stdout')    
+    def test_preprocess_config_type(self, mock_stdout):
+        """PREPROCESS: Check config values of parameters listed in config_file_2 when this file is set using the CLI argument."""
+        sys.argv = ['test_preprocess_params.py', '--config_file', config_file_2]
+        self.assertIsInstance(preprocess_params['preprocess_test_var'], str)
+        self.assertIsInstance(preprocess_params['split'], list)
+        self.assertIsInstance(preprocess_params['only_cross_study'], bool)
+        self.assertIsInstance(preprocess_params['study_number'], int)
+        self.assertIsInstance(preprocess_params['train_percent'], float)
+    '''
+
+
+       
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Created two types of unit tests - 1) check precedence/order of how parameters are read and prioritized, and 2) check types of parameters for boolean, string, integer, float, and lists. Currently there are issues with boolean, lists, and numeric values when read from a config file. 

Also renamed the folder `test` to `tests`. We can remove the folder `test`. 

Let me know if there's anything I need to change/fix. I wasn't sure if it is redundant to check all config types - train, infer, test. Also can break up the long script into two for better readability. 