### PR TITLE
add param input_supp_data_dir

### DIFF
--- a/improvelib/initializer/cli_params_def.py
+++ b/improvelib/initializer/cli_params_def.py
@@ -48,6 +48,12 @@ improve_basic_conf = [
      # "required": True, # TODO remove default if this is required param
      "help": "File format to save the ML data file (e.g., '.pt', '.tfrecords')",
     },
+    # ---------------------------------------
+    {"name": "input_supp_data_dir",
+     "type": str,
+     "default": argparse.SUPPRESS,
+     "help": "Dir containing supplementary data in addition to benchmark data (usually model-specific data).",
+    },
 
 ]
 


### PR DESCRIPTION
Address #68
Created param `input_supp_data_dir`. It's available in all model scripts and suppressed by default.