### PR TITLE
Natasha/metric type

### DIFF
--- a/improvelib/initializer/cli_params_def.py
+++ b/improvelib/initializer/cli_params_def.py
@@ -296,7 +296,7 @@ improve_infer_conf = [
      # "type": bool,
      "type": str2bool,
      # "action": "store_true",
-     "default": False,
+     "default": True,
      "help": "Calculate scores in the inference script (this is optional; \
              should not be required during inference).",
     },

--- a/improvelib/initializer/cli_params_def.py
+++ b/improvelib/initializer/cli_params_def.py
@@ -163,11 +163,11 @@ improve_train_conf = [
      "help": "Validation batch size."
     },
     # ---------------------------------------
-    #{"name": "loss",  # TODO used in compute_metrics(), but probably can be removed
-    # "type": str,
-    # "default": "mse",
-    # "help": "[Dep?] Loss metric."
-    #},
+    {"name": "loss",  # TODO used in compute_metrics(), but probably can be removed
+     "type": str,
+     "default": "mse",
+     "help": "[Dep?] Loss metric."
+    },
     {"name": "early_stop_metric",  # [Req] TODO consider moving to app or model (with patience)
      "type": str,
      "default": "mse",
@@ -276,11 +276,11 @@ improve_infer_conf = [
      # "required": True, # TODO remove default if this is required param
      "help": "[Dep?] File format to save the trained model."
     },
-    #{"name": "loss",  
-    # "type": str,
-    # "default": "mse",
-    # "help": "[Dep?] Loss metric."
-    #},
+    {"name": "loss",  
+     "type": str,
+     "default": "mse",
+     "help": "[Dep?] Loss metric."
+    },
     # ---------------------------------------
     {"name": "input_data_dir",
      "type": str,

--- a/improvelib/initializer/cli_params_def.py
+++ b/improvelib/initializer/cli_params_def.py
@@ -163,11 +163,11 @@ improve_train_conf = [
      "help": "Validation batch size."
     },
     # ---------------------------------------
-    {"name": "loss",  # TODO used in compute_metrics(), but probably can be removed
-     "type": str,
-     "default": "mse",
-     "help": "[Dep?] Loss metric."
-    },
+    #{"name": "loss",  # TODO used in compute_metrics(), but probably can be removed
+    # "type": str,
+    # "default": "mse",
+    # "help": "[Dep?] Loss metric."
+    #},
     {"name": "early_stop_metric",  # [Req] TODO consider moving to app or model (with patience)
      "type": str,
      "default": "mse",
@@ -276,11 +276,11 @@ improve_infer_conf = [
      # "required": True, # TODO remove default if this is required param
      "help": "[Dep?] File format to save the trained model."
     },
-    {"name": "loss",  
-     "type": str,
-     "default": "mse",
-     "help": "[Dep?] Loss metric."
-    },
+    #{"name": "loss",  
+    # "type": str,
+    # "default": "mse",
+    # "help": "[Dep?] Loss metric."
+    #},
     # ---------------------------------------
     {"name": "input_data_dir",
      "type": str,

--- a/improvelib/initializer/cli_params_def.py
+++ b/improvelib/initializer/cli_params_def.py
@@ -296,7 +296,7 @@ improve_infer_conf = [
      # "type": bool,
      "type": str2bool,
      # "action": "store_true",
-     "default": True,
+     "default": False,
      "help": "Calculate scores in the inference script (this is optional; \
              should not be required during inference).",
     },

--- a/improvelib/initializer/cli_params_def.py
+++ b/improvelib/initializer/cli_params_def.py
@@ -180,6 +180,12 @@ improve_train_conf = [
      "help": "Iterations to wait for a validation metric to get worse before \
              stop training.",
     },
+    {"name": "metric_type", 
+     "type": str,
+     "default": "regression",
+     "help": "Metrics appropriate for given task. Options are 'regression' \
+             or 'classification'",
+    },
     # ---------------------------------------
     # TODO y_data_preds_suffix, json_scores_suffix, pred_col_name_suffix
     # are currently used in utils.py (previously framework.py)
@@ -293,6 +299,12 @@ improve_infer_conf = [
      "default": False,
      "help": "Calculate scores in the inference script (this is optional; \
              should not be required during inference).",
+    },
+    {"name": "metric_type", 
+     "type": str,
+     "default": "regression",
+     "help": "Metrics appropriate for given task. Options are 'regression' \
+             or 'classification'",
     },
 
 ]

--- a/improvelib/metrics.py
+++ b/improvelib/metrics.py
@@ -16,7 +16,7 @@ def str2Class(str):
     return getattr(sys.modules[__name__], str)
 
 
-def compute_metrics(y_true, y_pred, metrics):
+def compute_metrics(y_true, y_pred, metric_type):
     """Compute the specified set of metrics.
 
     Parameters
@@ -34,6 +34,13 @@ def compute_metrics(y_true, y_pred, metrics):
         A dictionary of evaluated metrics.
     """
     scores = {}
+    if metric_type == "classification":
+        metrics = ["acc", "recall", "precision", "f1", "auc", "aupr"]
+    elif metric_type == "regression":
+        metrics = ["rmse", "pcc", "scc", "r2"]
+    else:
+        print("Invalid metric_type")
+        
     for mtstr in metrics:
         mapstr = mtstr
         if mapstr == "pcc":

--- a/improvelib/metrics.py
+++ b/improvelib/metrics.py
@@ -37,10 +37,10 @@ def compute_metrics(y_true, y_pred, metric_type):
     if metric_type == "classification":
         metrics = ["acc", "recall", "precision", "f1", "auc", "aupr"]
     elif metric_type == "regression":
-        metrics = ["rmse", "pcc", "scc", "r2"]
+        metrics = ["mse", "rmse", "pcc", "scc", "r2"]
     else:
         print("Invalid metric_type")
-        
+
     for mtstr in metrics:
         mapstr = mtstr
         if mapstr == "pcc":

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -588,15 +588,13 @@ def compute_performance_scores(params: Dict,
                                y_true: np.array,
                                y_pred: np.array,
                                stage: str,
-                               outdir: Union[Path, str],
-                               metric_type: str):
+                               outdir: Union[Path, str]):
     """Evaluate predictions according to specified metrics.
 
     Metrics are evaluated. Scores are stored in specified path and returned.
 
     :params array y_true: Array with ground truth values.
     :params array y_pred: Array with model predictions.
-    :params listr metrics: List of strings with metrics to evaluate.
     :params Dict outdtd: Dictionary with path to store scores.
     :params str stage: String specified if evaluation is with respect to
             validation or testing set.
@@ -605,7 +603,7 @@ def compute_performance_scores(params: Dict,
     :rtype: dict
     """
     # Compute multiple performance scores
-    scores = compute_metrics(y_true, y_pred, metric_type)
+    scores = compute_metrics(y_true, y_pred, params["metric_type"])
 
     # Add val_loss metric
     key = f"{stage}_loss"

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -589,7 +589,7 @@ def compute_performance_scores(params: Dict,
                                y_pred: np.array,
                                stage: str,
                                outdir: Union[Path, str],
-                               metrics: List):
+                               metric_type: str):
     """Evaluate predictions according to specified metrics.
 
     Metrics are evaluated. Scores are stored in specified path and returned.
@@ -605,7 +605,7 @@ def compute_performance_scores(params: Dict,
     :rtype: dict
     """
     # Compute multiple performance scores
-    scores = compute_metrics(y_true, y_pred, metrics)
+    scores = compute_metrics(y_true, y_pred, metric_type)
 
     # Add val_loss metric
     key = f"{stage}_loss"
@@ -631,7 +631,6 @@ def compute_performance_scores(params: Dict,
     return scores
 
 
-compute_performace_scores = compute_performance_scores  # for backwards compatibility
 
 
 def check_path_and_files(folder_name: str, file_list: List, inpath: Path) -> Path:

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -605,8 +605,8 @@ def compute_performance_scores(params: Dict,
     scores = compute_metrics(y_true, y_pred, params["metric_type"])
 
     # Add val_loss metric
-    key = f"{stage}_loss"
-    scores[key] = scores[params["loss"]]
+    #key = f"{stage}_loss"
+    #scores[key] = scores[params["loss"]]
 
     scores_fname = f"{stage}_scores.json"
     scorespath = Path(params["output_dir"]) / scores_fname

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -480,7 +480,6 @@ def store_predictions_df(params: Dict,
                          y_true: np.array,
                          y_pred: np.array,
                          stage: str,
-                         outdir: Union[Path, str],
                          round_decimals: int = 4):
     """Store predictions with accompanying data frame.
 
@@ -496,7 +495,7 @@ def store_predictions_df(params: Dict,
 
             [stage]_[params['y_data_suffix']]_
 
-    :params Dict params: Dictionary of CANDLE/IMPROVE parameters read.
+    :params Dict params: Dictionary of IMPROVE parameters.
     :params Dict indtd: Dictionary specifying paths of input data.
     :params Dict outdtd: Dictionary specifying paths for ouput data.
     :params array y_true: Ground truth.
@@ -524,22 +523,14 @@ def store_predictions_df(params: Dict,
     # ydf_fname = f"{stage}_{params['y_data_suffix']}.csv"
     ydf_fname = f"{stage}_y_data.csv"
     # ydf_fpath = Path(params[f"{stage}_ml_data_dir"]) / ydf_fname
+    ydf_fpath = Path(params["output_dir"]) / ydf_fname
 
-    # check for ml_data_outdir and output_dir in params and use the one that is available
-    # this ensures backward compatibility with previous versions of framework.py
-    if f"{stage}_ml_data_dir" in params:
-        ydf_fpath = Path(params[f"{stage}_ml_data_dir"]) / ydf_fname
-    elif "output_dir" in params:
-        ydf_fpath = Path(params["output_dir"]) / ydf_fname
-    else:
-        raise Exception(
-            f"ERROR ! Neither '{stage}_ml_data_dir' not 'output_dir' found in params.\n")
 
     # output df fname
     ydf_out_fname = ydf_fname.split(".")[0] + "_predicted.csv"
         # ".")[0] + "_" + params["y_data_preds_suffix"] + ".csv"
     # ydf_out_fpath = Path(params["ml_data_outdir"]) / ydf_out_fname
-    ydf_out_fpath = Path(outdir) / ydf_out_fname
+    ydf_out_fpath = Path(params["output_dir"]) / ydf_out_fname
 
     # if indtd["df"] is not None:
     if ydf_fpath.exists():

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -587,15 +587,14 @@ def store_predictions_df(params: Dict,
 def compute_performance_scores(params: Dict,
                                y_true: np.array,
                                y_pred: np.array,
-                               stage: str,
-                               outdir: Union[Path, str]):
+                               stage: str):
     """Evaluate predictions according to specified metrics.
 
     Metrics are evaluated. Scores are stored in specified path and returned.
 
+    :params Dict params: Dictionary with IMPROVE parameters.
     :params array y_true: Array with ground truth values.
     :params array y_pred: Array with model predictions.
-    :params Dict outdtd: Dictionary with path to store scores.
     :params str stage: String specified if evaluation is with respect to
             validation or testing set.
 
@@ -607,14 +606,10 @@ def compute_performance_scores(params: Dict,
 
     # Add val_loss metric
     key = f"{stage}_loss"
-    # scores[key] = scores["mse"]
     scores[key] = scores[params["loss"]]
 
-    # fname = f"val_{params['json_scores_suffix']}.json"
-    # scores_fname = f"{stage}_{params['json_scores_suffix']}.json"
     scores_fname = f"{stage}_scores.json"
-    # scorespath = Path(params["ml_data_outdir"]) / scores_fname
-    scorespath = Path(outdir) / scores_fname
+    scorespath = Path(params["output_dir"]) / scores_fname
 
     with open(scorespath, "w", encoding="utf-8") as f:
         json.dump(scores, f, ensure_ascii=False, indent=4)

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -476,11 +476,13 @@ def save_stage_ydf(ydf: pd.DataFrame, params: Dict, stage: str):
     return None
 
 
-def store_predictions_df(params: Dict,
-                         y_true: np.array,
+def store_predictions_df(y_true: np.array,
                          y_pred: np.array,
                          stage: str,
+                         y_col_name: str,
+                         output_dir: str,
                          round_decimals: int = 4):
+
     """Store predictions with accompanying data frame.
 
     This allows to trace original data evaluated (e.g. drug and cell
@@ -495,11 +497,13 @@ def store_predictions_df(params: Dict,
 
             [stage]_[params['y_data_suffix']]_
 
-    :params Dict params: Dictionary of IMPROVE parameters.
-    :params Dict indtd: Dictionary specifying paths of input data.
-    :params Dict outdtd: Dictionary specifying paths for ouput data.
     :params array y_true: Ground truth.
     :params array y_pred: Model predictions.
+    :params str stage: String specified if evaluation is with respect to
+            validation or testing set.
+    :params str y_col_name: Name of the column in the y_data predicted on.
+    :params str output_dir: Directory to write results.
+    :params int round_decimals: Number of decimals in output (default is 4).
 
     :return: Arrays with ground truth. This may have been read from an
              input data frame or from a processed PyTorch data file.
@@ -513,8 +517,8 @@ def store_predictions_df(params: Dict,
 
     # Define column names
     # pred_col_name = params["y_col_name"] + params["pred_col_name_suffix"]
-    pred_col_name = params["y_col_name"] + "_pred"
-    true_col_name = params["y_col_name"] + "_true"
+    pred_col_name = y_col_name + "_pred"
+    true_col_name = y_col_name + "_true"
 
     # -----------------------------
     # Attempt to concatenate raw predictions with y dataframe (e.g., df that
@@ -523,14 +527,14 @@ def store_predictions_df(params: Dict,
     # ydf_fname = f"{stage}_{params['y_data_suffix']}.csv"
     ydf_fname = f"{stage}_y_data.csv"
     # ydf_fpath = Path(params[f"{stage}_ml_data_dir"]) / ydf_fname
-    ydf_fpath = Path(params["output_dir"]) / ydf_fname
+    ydf_fpath = Path(output_dir) / ydf_fname
 
 
     # output df fname
     ydf_out_fname = ydf_fname.split(".")[0] + "_predicted.csv"
         # ".")[0] + "_" + params["y_data_preds_suffix"] + ".csv"
     # ydf_out_fpath = Path(params["ml_data_outdir"]) / ydf_out_fname
-    ydf_out_fpath = Path(params["output_dir"]) / ydf_out_fname
+    ydf_out_fpath = Path(output_dir) / ydf_out_fname
 
     # if indtd["df"] is not None:
     if ydf_fpath.exists():
@@ -543,7 +547,7 @@ def store_predictions_df(params: Dict,
         # pred_df = pd.DataFrame(y_pred, columns=[pred_col_name])  # Include only predicted values
         # This includes only predicted values
         pred_df = pd.DataFrame({true_col_name: y_true, pred_col_name: y_pred})
-        v1 = np.round(rsp_df[params["y_col_name"]].values.astype(np.float32),
+        v1 = np.round(rsp_df[y_col_name].values.astype(np.float32),
                       decimals=round_decimals)
         v2 = np.round(pred_df[true_col_name].values.astype(np.float32),
                       decimals=round_decimals)
@@ -551,7 +555,7 @@ def store_predictions_df(params: Dict,
         assert np.array_equal(
             v1, v2), "Loaded y data vector is not equal to the true vector"
         mm = pd.concat([rsp_df, pred_df], axis=1)
-        mm = mm.astype({params["y_col_name"]: np.float32,
+        mm = mm.astype({y_col_name: np.float32,
                         true_col_name: np.float32,
                         pred_col_name: np.float32})
         df = mm.round({true_col_name: round_decimals,
@@ -575,32 +579,35 @@ def store_predictions_df(params: Dict,
     return None
 
 
-def compute_performance_scores(params: Dict,
-                               y_true: np.array,
+def compute_performance_scores(y_true: np.array,
                                y_pred: np.array,
-                               stage: str):
+                               stage: str, 
+                               metric_type: str, 
+                               output_dir: str):
     """Evaluate predictions according to specified metrics.
 
     Metrics are evaluated. Scores are stored in specified path and returned.
 
-    :params Dict params: Dictionary with IMPROVE parameters.
+
     :params array y_true: Array with ground truth values.
     :params array y_pred: Array with model predictions.
     :params str stage: String specified if evaluation is with respect to
             validation or testing set.
+    :params str metric_type: Either classification or regression.
+    :params str output_dir: Directory to write results.
 
     :return: Python dictionary with metrics evaluated and corresponding scores.
     :rtype: dict
     """
     # Compute multiple performance scores
-    scores = compute_metrics(y_true, y_pred, params["metric_type"])
+    scores = compute_metrics(y_true, y_pred, metric_type)
 
     # Add val_loss metric
     #key = f"{stage}_loss"
     #scores[key] = scores[params["loss"]]
 
     scores_fname = f"{stage}_scores.json"
-    scorespath = Path(params["output_dir"]) / scores_fname
+    scorespath = Path(output_dir) / scores_fname
 
     with open(scorespath, "w", encoding="utf-8") as f:
         json.dump(scores, f, ensure_ascii=False, indent=4)
@@ -612,6 +619,8 @@ def compute_performance_scores(params: Dict,
         print("Validation scores:\n\t{}".format(scores))
     elif stage == "test":
         print("Inference scores:\n\t{}".format(scores))
+    else:
+        print("Invalid stage: must be 'val' or 'test'.")
     return scores
 
 


### PR DESCRIPTION
Fixes #69 -- LGBM natasha/framework-api updated in parallel

- removes extra "outdir" from store_predictions_df
- removes extra "outdir" from compute_performance_scores
- removes metrics from compute_performance_scores
- requires compute_performance_scores to be spelled correctly
- adds --metric_type
- deprecates --loss
- sets default for calc_infer_scores to True

Example calls now:
```
val_scores = frm.compute_performance_scores(
        params,
        y_true=val_true, 
        y_pred=val_pred, 
        stage="val"
    )
```

```
frm.store_predictions_df(
        params,
        y_true=val_true, 
        y_pred=val_pred, 
        stage="val"
    )
```
