### PR TITLE
Natasha/issues

### DIFF
--- a/improvelib/initializer/config.py
+++ b/improvelib/initializer/config.py
@@ -632,7 +632,6 @@ class Config:
                               pathToModelDir,
                               section='DEFAULT',
                               default_config=None,  # located in ModelDir
-                              default_model=None,
                               additional_definitions=None,
                               required=None,):
         """Initialize parameters from command line and config file."""

--- a/improvelib/initializer/stage_config.py
+++ b/improvelib/initializer/stage_config.py
@@ -50,7 +50,6 @@ class SectionConfig(Config):
     def initialize_parameters(self,
                               pathToModelDir,
                               default_config='default.cfg',
-                              default_model=None,
                               additional_cli_section=None,
                               additional_definitions=None,
                               required=None):
@@ -73,7 +72,6 @@ class SectionConfig(Config):
         p = super().initialize_parameters(pathToModelDir=pathToModelDir,
                                           section=self.section,
                                           default_config=default_config,
-                                          default_model=default_model,
                                           additional_definitions=self.options,
                                           required=required)
 

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -394,7 +394,7 @@ def get_file_format(file_format: Union[str, None] = None):
 
 
 # def build_ml_data_name(params: Dict, stage: str, file_format: str=""):
-def build_ml_data_name(params: Dict, stage: str):
+def build_ml_data_file_name(params: Dict, stage: str):
     """ Returns name of the ML/DL data file. E.g., train_data.pt
     TODO: consider renaming build_ml_data_file_name()
     Used in *preprocess*.py*, *train*.py, and *infer*.py

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -394,13 +394,11 @@ def get_file_format(file_format: Union[str, None] = None):
 
 
 # def build_ml_data_name(params: Dict, stage: str, file_format: str=""):
-def build_ml_data_file_name(params: Dict, stage: str):
+def build_ml_data_file_name(data_format: str, stage: str):
     """ Returns name of the ML/DL data file. E.g., train_data.pt
-    TODO: consider renaming build_ml_data_file_name()
     Used in *preprocess*.py*, *train*.py, and *infer*.py
     """
-    # data_file_format = get_file_format(file_format=file_format)
-    data_file_format = get_file_format(file_format=params["data_format"])
+    data_file_format = get_file_format(file_format=data_format)
     ml_data_file_name = stage + "_" + "data" + data_file_format
     return ml_data_file_name
 

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -437,29 +437,19 @@ def build_model_path(model_file_name: str, model_file_format: str, model_dir: Un
 #     return model_path
 
 
-def save_stage_ydf(ydf: pd.DataFrame, params: Dict, stage: str):
+def save_stage_ydf(ydf: pd.DataFrame, stage: str, output_dir: str):
     """ Save a subset of y data samples (rows of the input dataframe).
     The "subset" refers to one of the three stages involved in developing ML
     models, including: "train", "val", or "test".
 
     ydf : dataframe with y data samples
-    params : parameter dict
     stage (str) : "train", "val", or "test"
+    output_dir str: Directory to save to.
     """
-    # ydf_fname = f"{stage}_{params['y_data_suffix']}.csv"
     ydf_fname = f"{stage}_y_data.csv"
-
-    # check for ml_data_outdir and output_dir in params and use the one that is available
-    # this ensures backward compatibility with previous versions of framework.py
-    if "ml_data_outdir" in params:
-        ydf_fpath = Path(params["ml_data_outdir"]) / ydf_fname
-    elif "output_dir" in params:
-        ydf_fpath = Path(params["output_dir"]) / ydf_fname
-    else:
-        raise Exception(
-            "ERROR ! Neither 'ml_data_outdir' not 'output_dir' found in params.\n")
-
+    ydf_fpath = Path(output_dir) / ydf_fname
     ydf.to_csv(ydf_fpath, index=False)
+
     return None
 
 

--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -403,33 +403,22 @@ def build_ml_data_file_name(data_format: str, stage: str):
     return ml_data_file_name
 
 
-def build_model_path(params: Dict, model_dir: Union[Path, str]):
+def build_model_path(model_file_name: str, model_file_format: str, model_dir: Union[Path, str]):
     """ Build path to save the trained model.
     Used in *train*.py and *infer*.py
 
     Args:
-        params (dict): dict of IMPROVE/CANDLE parameters and parsed values.
+        model_file_name str: Name of model file.
+        model_file_format: Type of file for model (e.g. '.pt').
         model_dir (Path or str): dir path to save the model
 
     Returns:
         pathlib.Path: returns the build model dir path
     """
-    model_file_format = get_file_format(
-        file_format=params["model_file_format"])
+    standard_model_file_format = get_file_format(
+        file_format=model_file_format)
     model_path = Path(model_dir) / \
-        (params["model_file_name"] + model_file_format)
-
-    # # check for model_outdir and output_dir in params and use the one that is available
-    # # this ensures backward compatibility with previous versions of framework.py
-    # model_file_format = get_file_format(file_format=params["model_file_format"])
-    # if "model_outdir" is params:
-    #     model_dir = Path(model_dir)
-    # elif "output_dir" in params:
-    #     model_dir = Path(params["output_dir"])
-    # else:
-    #     raise Exception(
-    #         "ERROR ! Neither 'ml_data_outdir' not 'output_dir' found in params.\n")
-    # model_path = model_dir / (params["model_file_name"] + model_file_format)
+        (model_file_name + standard_model_file_format)
 
     return model_path
 


### PR DESCRIPTION
Fixes #99 
Fixes #96 

initialize_parameters now no longer has default_model

build_ml_data_name now build_ml_data_file_name

Arguments changed in these functions
build_ml_data_file_name(data_format: str, stage: str)
build_model_path(model_file_name: str, model_file_format: str, model_dir: Union[Path, str])
save_stage_ydf(ydf: pd.DataFrame, stage: str, output_dir: str)
