### PR TITLE
Added 'available_accelerators' to config file to choose GPU IDs. Also added functionalities to invoke model scripts in a singularity container.

### DIFF
--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -119,9 +119,9 @@ python workflow_csa.py --config_file <CONFIG_FILE>
 
 #### With singularity container:
 In csa_params.ini: < br / >
-    - Set use_singularity = True < br / >
-    - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER> < br / >
-    - Change other parameters if needed < br / >
+    - Set use_singularity = True  
+    - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>  
+    - Change other parameters if needed  
 
 To run cross study analysis with default configuration file (csa_params.ini):
 ```

--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -118,7 +118,7 @@ python workflow_csa.py --config_file <CONFIG_FILE>
 ```
 
 #### With singularity container:
-In csa_params.ini: < br / >
+In csa_params.ini:  
     - Set use_singularity = True  
     - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>  
     - Change other parameters if needed  

--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -118,10 +118,10 @@ python workflow_csa.py --config_file <CONFIG_FILE>
 ```
 
 #### With singularity container:
-In csa_params.ini:
-    - Set use_singularity = True
-    - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>
-    - Change other parameters if needed
+In csa_params.ini:< br / >
+    - Set use_singularity = True< br / >
+    - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>< br / >
+    - Change other parameters if needed< br / >
 
 To run cross study analysis with default configuration file (csa_params.ini):
 ```

--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -78,10 +78,8 @@ csa_data/raw_data/
     └── response.tsv
 ```
 
-### 6. To run cross study analysus using Parsl:
-
-Copy all the files in this directory to your model directory. Make sure to change the 'model_name' parameter in csa_params.ini to your <MODEL_NAME>.
-
+### 6. To run cross study analysis using Parsl:
+**Configuration file**:
 **csa_params.ini** contains parameters necessary for the workflow. The user can change the parameters inside this configuration file.
 
  - input_dir : Location of raw data for cross study analysis. 
@@ -97,6 +95,7 @@ Copy all the files in this directory to your model directory. Make sure to chang
     - hyperparameters_default.json : Contains default values of the hyperparameters for the model.
  - model_name: Name of the model for cross study analysis
  - epochs: Number of epochs for the model
+ - available_accelerators: List of GPU ids to launch the jobs. The required format is: ["id1","id2"]. For example, if you want to choose GPUs 0 and 1 set available_accelerators = ["0","1"]
  - y_col_name: Response variable used in the model. eg: auc
  - use_singularity: True, if the model files are available in a singularity container
  - singularity_image: Singularity image file (.sif) of the model scripts (optional)
@@ -105,7 +104,11 @@ Copy all the files in this directory to your model directory. Make sure to chang
 **hyperparameters.json** contains a dictionary of optimized hyperparameters for the models. The key to the dictionary is the model name, which contains another dictionary with source dataset names as keys. The two hyperparameters considered for this analysis are: batch_size and learning_rate. 
 The hyperparameters are optimized using [Supervisor](https://github.com/JDACS4C-IMPROVE/HPO).
 
- To run cross study analysis with default configuration file (csa_params.ini):
+#### Without singularity container:
+
+Copy all the files in this directory to your model directory. Make sure to change the 'model_name' parameter in csa_params.ini to your <MODEL_NAME>.
+
+To run cross study analysis with default configuration file (csa_params.ini):
 ```
 python workflow_csa.py
 ```
@@ -113,6 +116,22 @@ python workflow_csa.py
 ```
 python workflow_csa.py --config_file <CONFIG_FILE>
 ```
+
+#### With singularity container:
+In csa_params.ini:
+    - Set use_singularity = True
+    - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>
+    - Change other parameters if needed
+
+To run cross study analysis with default configuration file (csa_params.ini):
+```
+python workflow_csa.py
+```
+To run cross study analysis with a different configuration file:
+```
+python workflow_csa.py --config_file <CONFIG_FILE>
+```
+
 
 ### Reference
 1.	Yadu Babuji, Anna Woodard, Zhuozhao Li, Daniel S. Katz, Ben Clifford, Rohan Kumar, Luksaz Lacinski, Ryan Chard, Justin M. Wozniak, Ian Foster, Michael Wilde and Kyle Chard. "Parsl: Pervasive Parallel Programming in Python." 28th ACM International Symposium on High-Performance Parallel and Distributed Computing (HPDC). 2019. 10.1145/3307681.3325400

--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -118,10 +118,10 @@ python workflow_csa.py --config_file <CONFIG_FILE>
 ```
 
 #### With singularity container:
-In csa_params.ini:< br / >
-    - Set use_singularity = True< br / >
-    - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>< br / >
-    - Change other parameters if needed< br / >
+In csa_params.ini: < br / >
+    - Set use_singularity = True < br / >
+    - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER> < br / >
+    - Change other parameters if needed < br / >
 
 To run cross study analysis with default configuration file (csa_params.ini):
 ```

--- a/workflows/parsl_csa/csa_params.ini
+++ b/workflows/parsl_csa/csa_params.ini
@@ -10,6 +10,7 @@ split = ["0", "1", "2"]
 model_name = <YOUR_MODEL_NAME>
 only_cross_study = False
 epochs = 100
+available_accelerators=["0","1"]
 
 [Preprocess]
 

--- a/workflows/parsl_csa/csa_params.ini
+++ b/workflows/parsl_csa/csa_params.ini
@@ -3,6 +3,7 @@ input_dir = ./csa_data/raw_data
 output_dir=./improve_output
 y_col_name = auc
 use_singularity = False
+singularity_image = <YOUR_SINGULARITY_IMAGE.sif>
 hyperparameters_file = ./hyperparameters_default.json
 source_datasets = ["gCSI", "CCLE", "GDSCv1", "GDSCv2", "CTRPv2"]
 target_datasets = ["gCSI", "CCLE", "GDSCv1", "GDSCv2", "CTRPv2"]

--- a/workflows/parsl_csa/csa_params_def.py
+++ b/workflows/parsl_csa/csa_params_def.py
@@ -38,6 +38,12 @@ additional_definitions = [
      "default": 10,
      "help": "Number of epochs"
     },
+    {"name": "available_accelerators",
+     "nargs" : "+",
+     "type": str,
+     "default": ["0", "1"],
+     "help": "target_datasets for cross study analysis"
+    },
     {"name": "use_singularity",
      "type": bool,
      "default": True,

--- a/workflows/parsl_csa/csa_params_def.py
+++ b/workflows/parsl_csa/csa_params_def.py
@@ -42,7 +42,7 @@ additional_definitions = [
      "nargs" : "+",
      "type": str,
      "default": ["0", "1"],
-     "help": "target_datasets for cross study analysis"
+     "help": "GPU IDs to assign jobs"
     },
     {"name": "use_singularity",
      "type": bool,


### PR DESCRIPTION
Setting available_accelerators = ["0", "1"] inside csa_params.ini will assign jobs to GPUs 0 and 1, without having to change the workflow scripts.

If users have their model scripts inside a singularity image .sif file, they can set the following in csa_params.ini:
use_singularity = True 
singularity_image = <CONTAINER_IMAGE.sif>

Run the workflow: python workflow_csa.py

