### PR TITLE
Workflow/separate preprocess and add calc_infer_score

### DIFF
--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -110,6 +110,10 @@ Copy all the files in this directory to your model directory.
 Make sure to change the 'model_name' parameter in csa_params.ini to your <MODEL_NAME>.  
 Change the 'model_environment' variable to the name of your model conda environment.
 
+Preprocess the raw data:
+```
+python workflow_preprocess.py
+```
 To run cross study analysis with default configuration file (csa_params.ini):
 ```
 python workflow_csa.py
@@ -126,6 +130,10 @@ In csa_params.ini:
     - Change other parameters if needed  
 
 To run cross study analysis with default configuration file (csa_params.ini):
+Preprocess the raw data:
+```
+python workflow_preprocess.py
+```
 ```
 python workflow_csa.py
 ```

--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -129,7 +129,7 @@ In csa_params.ini:
     - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>  
     - Change other parameters if needed  
 
-To run cross study analysis with default configuration file (csa_params.ini):
+To run cross study analysis with default configuration file (csa_params.ini):  
 Preprocess the raw data:
 ```
 python workflow_preprocess.py

--- a/workflows/parsl_csa/README.md
+++ b/workflows/parsl_csa/README.md
@@ -129,11 +129,11 @@ In csa_params.ini:
     - singularity_image = <NAME_OF_YOUR_SINGULARITY_CONTAINER>  
     - Change other parameters if needed  
 
-To run cross study analysis with default configuration file (csa_params.ini):  
 Preprocess the raw data:
 ```
 python workflow_preprocess.py
 ```
+To run cross study analysis with default configuration file (csa_params.ini):  
 ```
 python workflow_csa.py
 ```

--- a/workflows/parsl_csa/workflow_csa.py
+++ b/workflows/parsl_csa/workflow_csa.py
@@ -114,6 +114,7 @@ def infer(params, source_data_name, target_data_name, split): #
                 str("--input_data_dir " + str(ml_data_dir)),
                 str("--input_model_dir " + str(model_dir)),
                 str("--output_dir " + str(infer_dir)),
+                str("--calc_infer_scores "+ "true"),
                 str("--y_col_name " + str(params['y_col_name']))
         ]
         result = subprocess.run(infer_run, capture_output=True,
@@ -125,6 +126,7 @@ def infer(params, source_data_name, target_data_name, split): #
                 "--input_data_dir", str(ml_data_dir),
                 "--input_model_dir", str(model_dir),
                 "--output_dir", str(infer_dir),
+                "--calc_infer_scores", "true",
                 "--y_col_name", str(params['y_col_name'])
             ]
         result = subprocess.run(infer_run, capture_output=True,

--- a/workflows/parsl_csa/workflow_csa.py
+++ b/workflows/parsl_csa/workflow_csa.py
@@ -61,95 +61,6 @@ logger = logging.getLogger(f'Start workflow')
 ################################ PARSL APPS ##################################
 ##############################################################################
 
-@python_app  
-def preprocess(inputs=[]): # 
-    import warnings
-    import subprocess
-    import improvelib.utils as frm
-    def build_split_fname(source_data_name, split, phase):
-        """ Build split file name. If file does not exist continue """
-        if split=='all':
-            return f"{source_data_name}_{split}.txt"
-        return f"{source_data_name}_split_{split}_{phase}.txt"
-    params=inputs[0]
-    source_data_name=inputs[1]
-    split=inputs[2]
-
-    split_nums=params['split']
-    # Get the split file paths
-    if len(split_nums) == 0:
-        # Get all splits
-        split_files = list((params['splits_path']).glob(f"{source_data_name}_split_*.txt"))
-        split_nums = [str(s).split("split_")[1].split("_")[0] for s in split_files]
-        split_nums = sorted(set(split_nums))
-    else:
-        split_files = []
-        for s in split_nums:
-            split_files.extend(list((params['splits_path']).glob(f"{source_data_name}_split_{s}_*.txt")))
-    files_joined = [str(s) for s in split_files]
-
-    print(f"Split id {split} out of {len(split_nums)} splits.")
-    # Check that train, val, and test are available. Otherwise, continue to the next split.
-    for phase in ["train", "val", "test"]:
-        fname = build_split_fname(source_data_name, split, phase)
-        if fname not in "\t".join(files_joined):
-            warnings.warn(f"\nThe {phase} split file {fname} is missing (continue to next split)")
-            continue
-
-    for target_data_name in params['target_datasets']:
-        ml_data_dir = params['ml_data_dir']/f"{source_data_name}-{target_data_name}"/ \
-                f"split_{split}"
-        if ml_data_dir.exists() is True:
-            continue
-        if params['only_cross_study'] and (source_data_name == target_data_name):
-            continue # only cross-study
-        print(f"\nSource data: {source_data_name}")
-        print(f"Target data: {target_data_name}")
-
-        params['ml_data_outdir'] = params['ml_data_dir']/f"{source_data_name}-{target_data_name}"/f"split_{split}"
-        frm.create_outdir(outdir=params["ml_data_outdir"])
-        if source_data_name == target_data_name:
-            # If source and target are the same, then infer on the test split
-            test_split_file = f"{source_data_name}_split_{split}_test.txt"
-        else:
-            # If source and target are different, then infer on the entire target dataset
-            test_split_file = f"{target_data_name}_all.txt"
-
-        # Preprocess  data
-        print("\nPreprocessing")
-        train_split_file = f"{source_data_name}_split_{split}_train.txt"
-        val_split_file = f"{source_data_name}_split_{split}_val.txt"
-        print(f"train_split_file: {train_split_file}")
-        print(f"val_split_file:   {val_split_file}")
-        print(f"test_split_file:  {test_split_file}")
-        print(f"ml_data_outdir:   {params['ml_data_outdir']}")
-        if params['use_singularity']:
-            preprocess_run = ["singularity", "exec", "--nv",
-                params['singularity_image'], "preprocess.sh",
-                str("--train_split_file " + str(train_split_file)),
-                str("--val_split_file " + str(val_split_file)),
-                str("--test_split_file " + str(test_split_file)),
-                str("--input_dir " + params['input_dir']),
-                str("--output_dir " + str(ml_data_dir)),
-                str("--y_col_name " + str(params['y_col_name']))
-            ]
-            result = subprocess.run(preprocess_run, capture_output=True,
-                                    text=True, check=True)
-        else:
-            preprocess_run = ["bash", "execute_in_conda.sh",params['model_environment'], 
-                params['preprocess_python_script'],
-                "--train_split_file", str(train_split_file),
-                "--val_split_file", str(val_split_file),
-                "--test_split_file", str(test_split_file),
-                "--input_dir", params['input_dir'], 
-                "--output_dir", str(ml_data_dir),
-                "--y_col_name", str(params['y_col_name'])
-            ]
-            result = subprocess.run(preprocess_run, capture_output=True,
-                                    text=True, check=True)
-    return {'source_data_name':source_data_name, 'split':split}
-
-
 @python_app 
 def train(params, hp_model, source_data_name, split): 
     import subprocess
@@ -236,7 +147,6 @@ params['model_outdir'] = Path(params['output_dir']) / 'models'
 params['infer_dir'] = Path(params['output_dir']) / 'infer'
 
 #Model scripts
-params['preprocess_python_script'] = f"{params['model_name']}_preprocess_improve.py"
 params['train_python_script'] = f"{params['model_name']}_train_improve.py"
 params['infer_python_script'] = f"{params['model_name']}_infer_improve.py"
 
@@ -249,16 +159,11 @@ hp_model = hp[params['model_name']]
 ##################### START PARSL PARALLEL EXECUTION #####################
 ##########################################################################
 
-##Preprocess execution with Parsl
-preprocess_futures=[]
-for source_data_name in params['source_datasets']:
-    for split in params['split']:
-            preprocess_futures.append(preprocess(inputs=[params, source_data_name, split])) 
-
 ##Train execution with Parsl
 train_futures=[]
-for future_p in preprocess_futures:
-    train_futures.append(train(params, hp_model, future_p.result()['source_data_name'], future_p.result()['split']))
+for source_data_name in params['source_datasets']:
+    for split in params['split']:
+        train_futures.append(train(params, hp_model, source_data_name, split))
 
 ##Infer execution with Parsl
 infer_futures =[]

--- a/workflows/parsl_csa/workflow_preprocess.py
+++ b/workflows/parsl_csa/workflow_preprocess.py
@@ -1,0 +1,179 @@
+import parsl
+from parsl import python_app
+import subprocess
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.providers import LocalProvider
+from time import time
+from typing import Sequence, Tuple, Union
+from pathlib import Path
+import logging
+import sys
+import json
+
+import csa_params_def as CSA
+import improvelib.utils as frm
+from improvelib.applications.drug_response_prediction.config import DRPPreprocessConfig
+
+# Initialize parameters for CSA
+additional_definitions = CSA.additional_definitions
+filepath = Path(__file__).resolve().parent
+cfg = DRPPreprocessConfig() 
+params = cfg.initialize_parameters(
+    pathToModelDir=filepath,
+    default_config="csa_params.ini",
+    additional_definitions=additional_definitions
+)
+
+##### CONFIG FOR LAMBDA ######
+#available_accelerators: Union[int, Sequence[str]] = 8
+worker_port_range: Tuple[int, int] = (10000, 20000)
+retries: int = 1
+
+config_lambda = Config(
+    retries=retries,
+    executors=[
+        HighThroughputExecutor(
+            address='127.0.0.1',
+            label="htex_preprocess",
+            cpu_affinity="alternating",
+            #max_workers_per_node=2, ## IS NOT SUPPORTED IN  Parsl version: 2023.06.19. CHECK HOW TO USE THIS???
+            worker_debug=True,
+            worker_port_range=worker_port_range,
+            provider=LocalProvider(
+                init_blocks=1,
+                max_blocks=1,
+            ),
+        )
+    ],
+    strategy='simple',
+)
+
+parsl.clear()
+parsl.load(config_lambda)
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+fdir = Path(__file__).resolve().parent
+logger = logging.getLogger(f'Start workflow')
+
+##############################################################################
+################################ PARSL APPS ##################################
+##############################################################################
+
+@python_app  
+def preprocess(inputs=[]): # 
+    import warnings
+    import subprocess
+    import improvelib.utils as frm
+    def build_split_fname(source_data_name, split, phase):
+        """ Build split file name. If file does not exist continue """
+        if split=='all':
+            return f"{source_data_name}_{split}.txt"
+        return f"{source_data_name}_split_{split}_{phase}.txt"
+    params=inputs[0]
+    source_data_name=inputs[1]
+    split=inputs[2]
+
+    split_nums=params['split']
+    # Get the split file paths
+    if len(split_nums) == 0:
+        # Get all splits
+        split_files = list((params['splits_path']).glob(f"{source_data_name}_split_*.txt"))
+        split_nums = [str(s).split("split_")[1].split("_")[0] for s in split_files]
+        split_nums = sorted(set(split_nums))
+    else:
+        split_files = []
+        for s in split_nums:
+            split_files.extend(list((params['splits_path']).glob(f"{source_data_name}_split_{s}_*.txt")))
+    files_joined = [str(s) for s in split_files]
+
+    print(f"Split id {split} out of {len(split_nums)} splits.")
+    # Check that train, val, and test are available. Otherwise, continue to the next split.
+    for phase in ["train", "val", "test"]:
+        fname = build_split_fname(source_data_name, split, phase)
+        if fname not in "\t".join(files_joined):
+            warnings.warn(f"\nThe {phase} split file {fname} is missing (continue to next split)")
+            continue
+
+    for target_data_name in params['target_datasets']:
+        ml_data_dir = params['ml_data_dir']/f"{source_data_name}-{target_data_name}"/ \
+                f"split_{split}"
+        if ml_data_dir.exists() is True:
+            continue
+        if params['only_cross_study'] and (source_data_name == target_data_name):
+            continue # only cross-study
+        print(f"\nSource data: {source_data_name}")
+        print(f"Target data: {target_data_name}")
+
+        params['ml_data_outdir'] = params['ml_data_dir']/f"{source_data_name}-{target_data_name}"/f"split_{split}"
+        frm.create_outdir(outdir=params["ml_data_outdir"])
+        if source_data_name == target_data_name:
+            # If source and target are the same, then infer on the test split
+            test_split_file = f"{source_data_name}_split_{split}_test.txt"
+        else:
+            # If source and target are different, then infer on the entire target dataset
+            test_split_file = f"{target_data_name}_all.txt"
+
+        # Preprocess  data
+        print("\nPreprocessing")
+        train_split_file = f"{source_data_name}_split_{split}_train.txt"
+        val_split_file = f"{source_data_name}_split_{split}_val.txt"
+        print(f"train_split_file: {train_split_file}")
+        print(f"val_split_file:   {val_split_file}")
+        print(f"test_split_file:  {test_split_file}")
+        print(f"ml_data_outdir:   {params['ml_data_outdir']}")
+        if params['use_singularity']:
+            preprocess_run = ["singularity", "exec", "--nv",
+                params['singularity_image'], "preprocess.sh",
+                str("--train_split_file " + str(train_split_file)),
+                str("--val_split_file " + str(val_split_file)),
+                str("--test_split_file " + str(test_split_file)),
+                str("--input_dir " + params['input_dir']),
+                str("--output_dir " + str(ml_data_dir)),
+                str("--y_col_name " + str(params['y_col_name']))
+            ]
+            result = subprocess.run(preprocess_run, capture_output=True,
+                                    text=True, check=True)
+        else:
+            preprocess_run = ["bash", "execute_in_conda.sh",params['model_environment'], 
+                params['preprocess_python_script'],
+                "--train_split_file", str(train_split_file),
+                "--val_split_file", str(val_split_file),
+                "--test_split_file", str(test_split_file),
+                "--input_dir", params['input_dir'], 
+                "--output_dir", str(ml_data_dir),
+                "--y_col_name", str(params['y_col_name'])
+            ]
+            result = subprocess.run(preprocess_run, capture_output=True,
+                                    text=True, check=True)
+    return {'source_data_name':source_data_name, 'split':split}
+
+
+###############################
+####### CSA PARAMETERS ########
+###############################
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+fdir = Path(__file__).resolve().parent
+y_col_name = params['y_col_name']
+logger = logging.getLogger(f"{params['model_name']}")
+params = frm.build_paths(params)  # paths to raw data
+
+#Output directories for preprocess, train and infer
+params['ml_data_dir'] = Path(params['output_dir']) / 'ml_data' 
+
+#Model scripts
+params['preprocess_python_script'] = f"{params['model_name']}_preprocess_improve.py"
+
+##########################################################################
+##################### START PARSL PARALLEL EXECUTION #####################
+##########################################################################
+
+##Preprocess execution with Parsl
+preprocess_futures=[]
+for source_data_name in params['source_datasets']:
+    for split in params['split']:
+            preprocess_futures.append(preprocess(inputs=[params, source_data_name, split])) 
+
+for future_p in preprocess_futures:
+    print(future_p.result())


### PR DESCRIPTION
To speed up preprocess, we can use a different parsl config for preprocessing. Since preprocessing does not require GPUs it is better to separate it from the train and infer workflows. This will invoke multiple processes for speeding up preprocessing. 

To execute: 
Preprocess the raw data:
```
python workflow_preprocess.py
```
To run cross study analysis with default configuration file (csa_params.ini):  
```
python workflow_csa.py
```