### PR TITLE
give the option to not use model_file_format

### DIFF
--- a/improvelib/utils.py
+++ b/improvelib/utils.py
@@ -415,9 +415,13 @@ def build_model_path(model_file_name: str, model_file_format: str, model_dir: Un
     Returns:
         pathlib.Path: returns the build model dir path
     """
-    standard_model_file_format = get_file_format(
+    if model_file_format == "None":
+        model_path = Path(model_dir) / \
+        (model_file_name)
+    else:
+        standard_model_file_format = get_file_format(
         file_format=model_file_format)
-    model_path = Path(model_dir) / \
+        model_path = Path(model_dir) / \
         (model_file_name + standard_model_file_format)
 
     return model_path


### PR DESCRIPTION
Weird behavior where some models have folders to contain model-related files. 

Note that using the following function makes the directory name look like a file. 
```
modelpath = frm.build_model_path(
        model_file_name=params["model_file_name"],
        model_file_format=params["model_file_format"],
        model_dir=params["output_dir"] )
``` 

drwxr-xr-x 4 ac.sejones cels   104 Oct  4 11:22 **model.pt**
-rw-r--r-- 1 ac.sejones cels  4083 Oct  4 11:06 param_log_file.txt
-rw-r--r-- 1 ac.sejones cels   160 Oct  4 11:22 val_scores.json
-rw-r--r-- 1 ac.sejones cels 38999 Oct  4 11:22 val_y_data_predicted.csv

Added a fix to make it so model curators can just specify `None` for `model_file_format`. 