### PR TITLE
Make o/p directories for logging if not created already

### DIFF
--- a/workflows/parsl_csa/workflow_csa.py
+++ b/workflows/parsl_csa/workflow_csa.py
@@ -2,7 +2,6 @@ import json
 import logging
 import sys
 import time
-import os
 from pathlib import Path
 from typing import Sequence, Tuple, Union
 
@@ -69,6 +68,7 @@ def train(params, hp_model, source_data_name, split):
     import json
     import subprocess
     import time
+    import os
     from pathlib import Path
 
     hp = hp_model[source_data_name]
@@ -140,6 +140,7 @@ def infer(params, source_data_name, target_data_name, split):
     import subprocess
     import json
     import time
+    import os
     from pathlib import Path
 
     model_dir = params['model_dir'] / f"{source_data_name}" / f"split_{split}"

--- a/workflows/parsl_csa/workflow_csa.py
+++ b/workflows/parsl_csa/workflow_csa.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 import time
+import os
 from pathlib import Path
 from typing import Sequence, Tuple, Union
 
@@ -113,6 +114,8 @@ def train(params, hp_model, source_data_name, split):
         # Logger
         print(f"returncode = {result.returncode}")
         result_file_name_stdout = model_dir / 'logs.txt'
+        if model_dir.exists() is False: # If subprocess fails, model_dir may not be created and we need to write the log files in model_dir
+            os.makedirs(model_dir, exist_ok=True)
         with open(result_file_name_stdout, 'w') as file:
             file.write(result.stdout)
 
@@ -175,6 +178,8 @@ def infer(params, source_data_name, target_data_name, split):
     # Logger
     print(f"returncode = {result.returncode}")
     result_file_name_stdout = infer_dir / 'logs.txt'
+    if infer_dir.exists() is False: 
+        os.makedirs(infer_dir, exist_ok=True)
     with open(result_file_name_stdout, 'w') as file:
         file.write(result.stdout)
 

--- a/workflows/parsl_csa/workflow_preprocess.py
+++ b/workflows/parsl_csa/workflow_preprocess.py
@@ -2,7 +2,6 @@ import json
 import logging
 import sys
 import time
-import os
 from pathlib import Path
 from typing import Sequence, Tuple, Union
 
@@ -68,6 +67,7 @@ def preprocess(inputs=[]):
     import json
     import subprocess
     import time
+    import os
     import warnings
     from pathlib import Path
 

--- a/workflows/parsl_csa/workflow_preprocess.py
+++ b/workflows/parsl_csa/workflow_preprocess.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 import time
+import os
 from pathlib import Path
 from typing import Sequence, Tuple, Union
 
@@ -162,6 +163,8 @@ def preprocess(inputs=[]):
         # Logger
         print(f"returncode = {result.returncode}")
         result_file_name_stdout = ml_data_dir / 'logs.txt'
+        if ml_data_dir.exists() is False: 
+            os.makedirs(ml_data_dir, exist_ok=True)
         with open(result_file_name_stdout, 'w') as file:
             file.write(result.stdout)
 


### PR DESCRIPTION
@wilke  pointed out that if the subprocess call fails inside the parsl app for some reason (eg: missing model scripts), the corresponding output dirs (model_dir, infer_dir or ml_data_dir) will not be created. So, we need to check if the output directories exist and create them if needed, to save the log files.

