### PR TITLE
exist_ok=True

### DIFF
--- a/improvelib/initializer/config.py
+++ b/improvelib/initializer/config.py
@@ -722,7 +722,7 @@ class Config:
         # Create output directory if not exists
         if not os.path.isdir(self.output_dir):
             self.logger.debug("Creating output directory: %s", self.output_dir)
-            os.makedirs(self.output_dir)
+            os.makedirs(self.output_dir, exist_ok=True)
         # Save parameters to file
         self.logger.debug("Saving final parameters to file.")
         # Save final configuration to file


### PR DESCRIPTION
just added `exist_ok=True` to `os.makedirs(self.output_dir)` because it's causing errors with deephyper